### PR TITLE
Add a Redis-based token bucket rate limiter

### DIFF
--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,0 +1,117 @@
+// Package ratelimit implements a distributed rate limiter backed by a Redis
+// server.
+//
+// The Limiter type provides a token bucket rate limiter with configurable
+// throughput (rate) and capacity. The operation of the rate limiter is atomic
+// and has should in principle be as accurate as the Redis server's system clock
+// allows.
+//
+// Each token bucket is stored as a Redis hash in a single key, meaning that
+// this package should work without modification in a Redis cluster environment,
+// where you can control how limiters are distributed across slots using the
+// usual mechanisms (e.g. "hash tags" in keys).
+package ratelimit
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+var (
+	//go:embed token_bucket.lua
+	limiterCmd    string
+	limiterScript = redis.NewScript(limiterCmd)
+
+	ErrInvalidData   = errors.New("limiter: received invalid data")
+	ErrNegativeInput = errors.New("limiter: input values must be non-negative")
+)
+
+type Limiter struct {
+	Client redis.Cmdable
+}
+
+type Result struct {
+	OK        bool          // whether the request was entirely fulfilled
+	Tokens    int           // number of tokens granted
+	Remaining int           // number of tokens remaining
+	Reset     time.Duration // time until bucket is full
+}
+
+// Prepare stores the limiter script in the Redis script cache so that it can be
+// more efficiently called with EVALSHA.
+func (l Limiter) Prepare(ctx context.Context) error {
+	return limiterScript.Load(ctx, l.Client).Err()
+}
+
+// Take requests a specified number of tokens from the token bucket stored in
+// the named key, while also specifying the default rate and capacity for the
+// bucket. It returns the Result of the request, and the first error
+// encountered, if any.
+//
+// If the token bucket already exists at the given key, the rate and capacity
+// set in the bucket will be used, otherwise the values provided will be set
+// when creating the bucket.
+//
+// Note: if >1 tokens are requested the Result may indicate partial fulfillment
+// of the request by setting OK == false but Tokens > 0 on the Result.
+func (l Limiter) Take(ctx context.Context, key string, tokens, rate, capacity int) (*Result, error) {
+	if tokens < 0 {
+		return nil, fmt.Errorf("%w (tokens=%d)", ErrNegativeInput, tokens)
+	}
+	if rate < 0 {
+		return nil, fmt.Errorf("%w (rate=%d)", ErrNegativeInput, rate)
+	}
+	if capacity < 0 {
+		return nil, fmt.Errorf("%w (capacity=%d)", ErrNegativeInput, capacity)
+	}
+	cmd := limiterScript.Run(ctx, l.Client, []string{key}, tokens, rate, capacity)
+	return makeResult(tokens, cmd)
+}
+
+// SetOptions sets the desired rate and capacity for the token bucket stored in
+// the named key. It returns the first error encountered, if any.
+//
+// Note that SetOptions applies a one minute TTL on the specified key, meaning
+// that options will only be preserved if token requests against this key occur
+// within that interval.
+//
+// SetOptions is provided so that a front-of-stack rate limiter can call Take
+// without needing to know the (possibly user-dependent) rate and capacity for
+// the specific limiter being queried. If the token is granted, the request can
+// then look up the appropriate context for the request and call SetOptions to
+// ensure that future requests are handled with the correct rate and capacity.
+func (l Limiter) SetOptions(ctx context.Context, key string, rate, capacity int) error {
+	if rate < 0 {
+		return fmt.Errorf("%w (rate=%d)", ErrNegativeInput, rate)
+	}
+	if capacity < 0 {
+		return fmt.Errorf("%w (capacity=%d)", ErrNegativeInput, capacity)
+	}
+	err := l.Client.HSet(ctx, key, "rate", rate, "capacity", capacity).Err()
+	if err != nil {
+		return err
+	}
+	return l.Client.Expire(ctx, key, time.Minute).Err()
+}
+
+func makeResult(tokens int, cmd *redis.Cmd) (*Result, error) {
+	s, err := cmd.Int64Slice()
+	if err != nil {
+		return nil, err
+	}
+	if len(s) != 3 {
+		return nil, fmt.Errorf("%w (len=%d)", ErrInvalidData, len(s))
+	}
+	result := &Result{
+		OK:        int(s[0]) == tokens,
+		Tokens:    int(s[0]),
+		Remaining: int(s[1]),
+		Reset:     time.Duration(s[2]) * time.Second,
+	}
+	return result, nil
+}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,0 +1,107 @@
+package ratelimit
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiterIntegration(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		t.Skip("REDIS_URL is not set")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts, err := redis.ParseURL(redisURL)
+	require.NoError(t, err)
+
+	client := redis.NewClient(opts)
+	limiter := Limiter{Client: client}
+	require.NoError(t, limiter.Prepare(ctx))
+
+	// result counters
+	permitted := 0
+	denied := 0
+
+	// test parameters
+	duration := 10
+	demandRate := 200
+
+	// rate limiter parameters
+	rate := 42
+	capacity := 5
+
+	deadline := time.After(time.Duration(duration) * time.Second)
+	ticker := time.NewTicker(time.Second / time.Duration(demandRate))
+
+Outer:
+	for {
+		select {
+		case <-ticker.C:
+			r, err := limiter.Take(ctx, "limit:testkey", 1, rate, capacity)
+			require.NoError(t, err)
+			if r.OK {
+				permitted++
+			} else {
+				denied++
+			}
+		case <-deadline:
+			break Outer
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	expectedTotal := demandRate * duration
+	expectedPermitted := rate * duration
+
+	// allow up to 1% error
+	assert.InDelta(t, expectedTotal, permitted+denied, float64(expectedTotal/100))
+	assert.InDelta(t, expectedPermitted, permitted, float64(expectedPermitted/100))
+}
+
+func TestLimiterTakeWithNegativeInputsReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	limiter := Limiter{}
+	{
+		_, err := limiter.Take(ctx, "testkey", -1, 1, 1)
+		require.ErrorIs(t, err, ErrNegativeInput)
+	}
+	{
+		_, err := limiter.Take(ctx, "testkey", 1, -1, 1)
+		require.ErrorIs(t, err, ErrNegativeInput)
+	}
+	{
+		_, err := limiter.Take(ctx, "testkey", 1, 1, -1)
+		require.ErrorIs(t, err, ErrNegativeInput)
+	}
+}
+
+func TestLimiterSetOptionsWithNegativeInputsReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	limiter := Limiter{}
+	{
+		err := limiter.SetOptions(ctx, "testkey", -1, 1)
+		require.ErrorIs(t, err, ErrNegativeInput)
+	}
+	{
+		err := limiter.SetOptions(ctx, "testkey", 1, -1)
+		require.ErrorIs(t, err, ErrNegativeInput)
+	}
+}

--- a/ratelimit/token_bucket.lua
+++ b/ratelimit/token_bucket.lua
@@ -1,0 +1,42 @@
+-- If the key doesn't exist and the rate + capacity arguments are not provided,
+-- the default rate limit is 50 req/s with a burst capacity of one minute's
+-- worth of requests, i.e. 50 * 60 = 3000.
+local default_rate = 50
+local default_capacity = 3000
+
+-- Load current state and time
+local state = redis.call('HMGET', KEYS[1], 'tokens', 'last_fill_time', 'rate', 'capacity')
+local time = redis.call('TIME')
+local now = tonumber(time[1], 10) * 1e6 + tonumber(time[2], 10)
+
+-- Process arguments. All are optional.
+local tokens_requested = tonumber(ARGV[1], 10) or 1
+
+-- If rate and capacity exist in the key, the arguments are ignored. This allows
+-- for workflows where custom limits exist for users but are not known until
+-- after the limiter has run.
+local rate = tonumber(state[3], 10) or tonumber(ARGV[2], 10) or default_rate
+local capacity = tonumber(state[4], 10) or tonumber(ARGV[3], 10) or default_capacity
+
+-- If this is a new limiter, the bucket is full
+local tokens = tonumber(state[1], 10) or capacity
+local last_fill_time = tonumber(state[2], 10) or now
+
+-- Add tokens accrued since the last fill
+local time_since_fill = now - last_fill_time
+local tokens_to_add = (time_since_fill / 1e6) * rate
+tokens = math.min(tokens + tokens_to_add, capacity)
+
+-- Grant as many (whole) tokens as we can and remove them from the bucket
+local tokens_granted = math.min(math.floor(tokens), tokens_requested)
+tokens = tokens - tokens_granted
+
+-- Calculate the time until the bucket is refilled
+local time_to_full_bucket = math.ceil((capacity - tokens) / rate)
+
+-- Expire the key one second after the bucket is full
+redis.call('EXPIRE', KEYS[1], time_to_full_bucket + 1)
+
+-- Save state and return the results
+redis.call('HSET', KEYS[1], 'tokens', tokens, 'last_fill_time', now, 'rate', rate, 'capacity', capacity)
+return {tokens_granted, math.floor(tokens), time_to_full_bucket}


### PR DESCRIPTION
Adds a basic token bucket rate limiter which operates on bucket metadata stored in Redis hashes. The token bucket calculations are done server-side in a Lua script, which allows the granting (or rejection) of token requests to be entirely atomic and free of any client-side races.

I've tested this on an M1 Max up to 20k req/s with multiple Go processes accessing a single limiter key in Redis and it performs well. Even at such high throughput, typical latency costs are of the order of 1-2ms, and tail latency costs of tens of milliseconds at most.

The rate limiter is accurate, with typical error of <1%.

A few example load test results can be found below. In each case, the test is performed against two identical Go HTTP server processes, both accessing the same Redis key.

At 20k req/s, the Redis server process saturated roughly 2.5 M1 Max cores.

1. Baseline: a no-op Go HTTP server, with no rate limiting code enabled.

       $ <urls vegeta attack -rate '20000/s' -duration 30s -keepalive -connections 24 -timeout 100ms -max-workers 24 -workers 1 | vegeta report
       Requests      [total, rate, throughput]         600000, 20000.06, 20000.04
       Duration      [total, attack, wait]             30s, 30s, 37µs
       Latencies     [min, mean, 50, 90, 95, 99, max]  25.167µs, 41.992µs, 36.972µs, 48.811µs, 58.63µs, 148.041µs, 2.102ms
       Bytes In      [total, mean]                     0, 0.00
       Bytes Out     [total, mean]                     0, 0.00
       Success       [ratio]                           100.00%
       Status Codes  [code:count]                      200:600000
       Error Set:

2. Heavy rate limiting: rate limited to 10 req/s with a burst capacity of 10 requests.

       $ <urls vegeta attack -rate '20000/s' -duration 30s -keepalive -connections 50 -timeout 100ms -max-workers 50 -workers 50 | vegeta report
       Requests      [total, rate, throughput]         597620, 19920.49, 10.30
       Duration      [total, attack, wait]             30.002s, 30s, 1.611ms
       Latencies     [min, mean, 50, 90, 95, 99, max]  463.416µs, 2.362ms, 2.268ms, 3.226ms, 3.576ms, 4.462ms, 15.574ms
       Bytes In      [total, mean]                     0, 0.00
       Bytes Out     [total, mean]                     0, 0.00
       Success       [ratio]                           0.05%
       Status Codes  [code:count]                      200:309  429:597311
       Error Set:
       429 Too Many Requests

3. Minimal rate limiting: rate limited to 18000 req/s with a burst capacity of 2000 requests.

       $ <urls vegeta attack -rate '20000/s' -duration 30s -keepalive -connections 50 -timeout 100ms -max-workers 50 -workers 50 | vegeta report
       Requests      [total, rate, throughput]         599951, 19998.40, 18046.27
       Duration      [total, attack, wait]             30s, 30s, 481.042µs
       Latencies     [min, mean, 50, 90, 95, 99, max]  241.75µs, 1.679ms, 1.456ms, 2.631ms, 3.129ms, 4.947ms, 31.87ms
       Bytes In      [total, mean]                     0, 0.00
       Bytes Out     [total, mean]                     0, 0.00
       Success       [ratio]                           90.24%
       Status Codes  [code:count]                      200:541396  429:58555
       Error Set:
       429 Too Many Requests