### PR TITLE
Switch to zap for logging

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	log    = logging.New("cache")
+	logger = logging.New("cache")
 	tracer = telemetry.Tracer("go", "cache")
 )
 
@@ -55,6 +55,7 @@ func NewCache[T any](
 }
 
 func (c *Cache[T]) Prepare(ctx context.Context) error {
+	log := logger.Sugar()
 	if c == nil {
 		log.Warnf("cache not configured: prepare is a no-op")
 		return nil
@@ -63,6 +64,7 @@ func (c *Cache[T]) Prepare(ctx context.Context) error {
 }
 
 func (c *Cache[T]) Get(ctx context.Context, key string, fetcher Fetcher[T]) (value T, err error) {
+	log := logger.Sugar()
 	if c == nil {
 		log.Warnf("cache not configured: fetching data directly")
 		return fetcher(ctx, key)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,9 +15,11 @@ import (
 var logger = logging.New("errors")
 
 func Init() {
+	log := logger.Sugar()
+
 	sentryDSN := os.Getenv("SENTRY_DSN")
 	if sentryDSN == "" {
-		logger.Warn("SENTRY_DSN not set: skipping Sentry initialization!")
+		log.Warn("SENTRY_DSN not set: skipping Sentry initialization!")
 		return
 	}
 
@@ -28,7 +30,7 @@ func Init() {
 		Release:          version.Version(),
 	})
 	if err != nil {
-		logger.Warnf("Failed to initialize Sentry client: %v", err)
+		log.Warnw("Failed to initialize Sentry client", "error", err)
 	}
 }
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -5,19 +5,18 @@ import (
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	ld "github.com/launchdarkly/go-server-sdk/v6"
+
 	"github.com/replicate/go/logging"
 )
 
 var currentClient *ld.LDClient
-var log = logging.New("flags")
-
-func init() {
-	logging.Configure(log)
-}
+var logger = logging.New("flags")
 
 func Init(key string) {
+	log := logger.Sugar()
+
 	config := ld.Config{
-		Logging: configureLogger(log),
+		Logging: configureLogger(logger),
 	}
 
 	if key == "" {
@@ -26,7 +25,7 @@ func Init(key string) {
 
 	client, err := ld.MakeCustomClient(key, config, 5*time.Second)
 	if err != nil {
-		log.WithError(err).Warn("failed to make LaunchDarkly client")
+		log.Warnw("failed to make LaunchDarkly client", "error", err)
 	}
 
 	if !client.Initialized() {
@@ -60,6 +59,8 @@ func KillSwitchSystem(name string) bool {
 }
 
 func lookupDefault(context *ldcontext.Context, name string, defaultVal bool) bool {
+	log := logger.Sugar()
+
 	if currentClient == nil {
 		return defaultVal
 	}

--- a/flags/logging.go
+++ b/flags/logging.go
@@ -1,26 +1,23 @@
 package flags
 
 import (
-	"io"
-
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-server-sdk/v6/ldcomponents"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 )
 
-func configureLogger(log logrus.FieldLogger) *ldcomponents.LoggingConfigurationBuilder {
+func configureLogger(log *zap.Logger) *ldcomponents.LoggingConfigurationBuilder {
 	if log == nil {
-		l := logrus.New()
-		l.SetOutput(io.Discard)
-		log = l
+		log = zap.NewNop()
 	}
-	log = log.WithField("component", "launchdarkly")
+	log = log.With(zap.String("component", "launchdarkly"))
 
+	l := log.Sugar()
 	logger := ldlog.NewDefaultLoggers()
-	logger.SetBaseLoggerForLevel(ldlog.Debug, &wrapLog{log.Debugln, log.Debugf})
-	logger.SetBaseLoggerForLevel(ldlog.Info, &wrapLog{log.Infoln, log.Infof})
-	logger.SetBaseLoggerForLevel(ldlog.Warn, &wrapLog{log.Warnln, log.Warnf})
-	logger.SetBaseLoggerForLevel(ldlog.Error, &wrapLog{log.Errorln, log.Errorf})
+	logger.SetBaseLoggerForLevel(ldlog.Debug, &wrapLog{l.Debugln, l.Debugf})
+	logger.SetBaseLoggerForLevel(ldlog.Info, &wrapLog{l.Infoln, l.Infof})
+	logger.SetBaseLoggerForLevel(ldlog.Warn, &wrapLog{l.Warnln, l.Warnf})
+	logger.SetBaseLoggerForLevel(ldlog.Error, &wrapLog{l.Errorln, l.Errorf})
 
 	logging := ldcomponents.Logging().Loggers(logger)
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/launchdarkly/go-sdk-common/v3 v3.0.1
 	github.com/launchdarkly/go-server-sdk/v6 v6.0.3
 	github.com/segmentio/ksuid v1.0.4
-	github.com/sirupsen/logrus v1.9.0
 	github.com/speps/go-hashids/v2 v2.0.1
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/contrib/detectors/gcp v1.15.0
@@ -19,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.14.0
 	go.opentelemetry.io/otel/sdk v1.14.0
 	go.opentelemetry.io/otel/trace v1.14.0
+	go.uber.org/zap v1.24.0
 	golang.org/x/tools v0.7.0
 	gotest.tools/gotestsum v1.9.0
 )
@@ -166,6 +166,7 @@ require (
 	github.com/sashamelentyev/usestdlibvars v1.23.0 // indirect
 	github.com/securego/gosec/v2 v2.15.0 // indirect
 	github.com/shazow/go-diff v0.0.0-20160112020656-b6b7b6733b8c // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/sivchari/containedctx v1.0.2 // indirect
 	github.com/sivchari/nosnakecase v1.7.0 // indirect
 	github.com/sivchari/tenv v1.7.1 // indirect
@@ -196,9 +197,8 @@ require (
 	gitlab.com/bosi/decorder v0.2.3 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.14.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
+	go.uber.org/atomic v1.10.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20220823124025-807a23277127 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230224173230-c95f2b4c22f2 // indirect
 	golang.org/x/mod v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -666,11 +666,11 @@ go.opentelemetry.io/otel/trace v1.14.0/go.mod h1:8avnQLK+CG77yNLUae4ea2JDQ6iT+go
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
-go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
+go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
-go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
-go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -4,93 +4,65 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConfigureLevel(t *testing.T) {
-	// *logrus.Logger
-	log1 := logrus.New()
-	// *logrus.Field
-	log2 := logrus.New().WithFields(logrus.Fields{"name": "elephant"})
-
+func TestNewConfigLevel(t *testing.T) {
 	defer os.Unsetenv("LOG_LEVEL")
 
 	// Default level is INFO
-	Configure(log1)
-	Configure(log2)
-	assert.Equal(t, logrus.InfoLevel, log1.GetLevel())
-	assert.Equal(t, logrus.InfoLevel, log2.Logger.GetLevel())
+	{
+		config := NewConfig()
+		assert.Equal(t, zap.InfoLevel, config.Level.Level())
+	}
 
 	// Unparseable level => INFO
 	os.Setenv("LOG_LEVEL", "garbage")
-	Configure(log1)
-	Configure(log2)
-	assert.Equal(t, logrus.InfoLevel, log1.GetLevel())
-	assert.Equal(t, logrus.InfoLevel, log2.Logger.GetLevel())
+	{
+		config := NewConfig()
+		assert.Equal(t, zap.InfoLevel, config.Level.Level())
+	}
 
 	os.Setenv("LOG_LEVEL", "warning")
-	Configure(log1)
-	Configure(log2)
-	assert.Equal(t, logrus.WarnLevel, log1.GetLevel())
-	assert.Equal(t, logrus.WarnLevel, log2.Logger.GetLevel())
+	{
+		config := NewConfig()
+		assert.Equal(t, zap.WarnLevel, config.Level.Level())
+	}
 
 	os.Setenv("LOG_LEVEL", "WARN")
-	Configure(log1)
-	Configure(log2)
-	assert.Equal(t, logrus.WarnLevel, log1.GetLevel())
-	assert.Equal(t, logrus.WarnLevel, log2.Logger.GetLevel())
+	{
+		config := NewConfig()
+		assert.Equal(t, zap.WarnLevel, config.Level.Level())
+	}
 
 	os.Setenv("LOG_LEVEL", "error")
-	Configure(log1)
-	Configure(log2)
-	assert.Equal(t, logrus.ErrorLevel, log1.GetLevel())
-	assert.Equal(t, logrus.ErrorLevel, log2.Logger.GetLevel())
+	{
+		config := NewConfig()
+		assert.Equal(t, zap.ErrorLevel, config.Level.Level())
+	}
 }
 
-func TestConfigureFormatter(t *testing.T) {
-	// *logrus.Logger
-	log1 := logrus.New()
-	// *logrus.Field
-	log2 := logrus.New().WithFields(logrus.Fields{"name": "elephant"})
-
+func TestNewConfigFormat(t *testing.T) {
 	defer os.Unsetenv("LOG_FORMAT")
 
 	// Default is production, i.e. JSON output
 	{
-		Configure(log1)
-		_, ok := log1.Formatter.(*logrus.JSONFormatter)
-		assert.True(t, ok)
-	}
-	{
-		Configure(log2)
-		_, ok := log2.Logger.Formatter.(*logrus.JSONFormatter)
-		assert.True(t, ok)
+		config := NewConfig()
+		assert.Equal(t, "json", config.Encoding)
 	}
 
 	// Unknown format => JSON output
 	os.Setenv("LOG_FORMAT", "yaml")
 	{
-		Configure(log1)
-		_, ok := log1.Formatter.(*logrus.JSONFormatter)
-		assert.True(t, ok)
-	}
-	{
-		Configure(log2)
-		_, ok := log2.Logger.Formatter.(*logrus.JSONFormatter)
-		assert.True(t, ok)
+		config := NewConfig()
+		assert.Equal(t, "json", config.Encoding)
 	}
 
 	os.Setenv("LOG_FORMAT", "development")
 	{
-		Configure(log1)
-		_, ok := log1.Formatter.(*logrus.TextFormatter)
-		assert.True(t, ok)
-	}
-	{
-		Configure(log2)
-		_, ok := log2.Logger.Formatter.(*logrus.TextFormatter)
-		assert.True(t, ok)
+		config := NewConfig()
+		assert.Equal(t, "console", config.Encoding)
 	}
 }

--- a/telemetry/errors.go
+++ b/telemetry/errors.go
@@ -1,0 +1,18 @@
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/getsentry/sentry-go"
+)
+
+type ErrorHandler struct{}
+
+func (eh ErrorHandler) Handle(err error) {
+	log := logger.Sugar()
+
+	err = fmt.Errorf("opentelemetry error: %w", err)
+
+	log.Warn(err)
+	sentry.CaptureException(err)
+}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -16,8 +16,11 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/replicate/go/logging"
 	"github.com/replicate/go/version"
 )
+
+var logger = logging.New("telemetry")
 
 type Telemetry struct {
 	*sdktrace.TracerProvider
@@ -31,6 +34,7 @@ func Start(ctx context.Context) (*Telemetry, error) {
 		return nil, err
 	}
 
+	otel.SetErrorHandler(ErrorHandler{})
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(
 		propagation.NewCompositeTextMapPropagator(


### PR DESCRIPTION
This switches our logging library over from logrus to zap. This is primarily so we get more detailed context (filename and line number) on all log entries by default.

In production this will also automatically capture stack traces for anything logged at Error or above.

There are also three other related changes in this PR:

1. All loggers inherit from one base logger

   Changes `logging.New` to return a configured child of a shared `baseLogger` than returning a brand new logger each time.

   This doesn't change much but it does mean we only read logging config from the environment once, rather than once per `logging.New` invocation.

2. Support storing and retrieving fields from context

   In order to allow request-local logger context to be passed between packages, we add `AddFields` and `GetFields` functions to the logging package, which can be used to store and retrieve a slice of `zap.Field` objects from a context object.

3. Add a default error handler for OTel that uses our loggers and Sentry.