### PR TITLE
Add a redis server for ratelimit integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,12 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      # Run redis so we can integration test the rate limiter
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4

--- a/script/test
+++ b/script/test
@@ -2,8 +2,15 @@
 
 set -eu
 
+: "${GITHUB_ACTIONS:=}"
+
 cd "$(dirname "$0")"
 cd ..
+
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+  REDIS_URL=redis://
+  export REDIS_URL
+fi
 
 # Run the tests for the entire repository.
 #


### PR DESCRIPTION
Runs a redis server so we can run the ratelimit integration tests in our Actions workflow.