### PR TITLE
upgrade to go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicate/go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/getsentry/sentry-go v0.22.0


### PR DESCRIPTION
Tests still pass.

I don't think this makes much, if any difference - API is already 1.20 and consuming this library. But we should keep up to date.