### PR TITLE
Forbid nil values

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -170,3 +170,16 @@ func TestCacheSet(t *testing.T) {
 
 	assert.NoError(t, err)
 }
+
+func TestCacheSetNilForbidden(t *testing.T) {
+	ctx := context.Background()
+
+	fresh := 10 * time.Second
+	stale := 30 * time.Second
+
+	client, _ := redismock.NewClientMock()
+	cache := NewCache[*testObj](client, "objects", fresh, stale)
+
+	err := cache.Set(ctx, "elephant", nil)
+	assert.ErrorIs(t, err, ErrNilValue)
+}


### PR DESCRIPTION
Even if T is a pointer type, an attempt to store a nil value is almost certainly a bug.

This updates Cache to reject Set for nil values.

(We'll need to bump `github.com/replicate/go` in API to pull this in once this is merged.)