### PR TITLE
Add support for multivariate flags 

### DIFF
--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -36,6 +36,18 @@ func TestKillSwitchSystemDefault(t *testing.T) {
 	require.True(t, KillSwitchSystem("anyflag"))
 }
 
+func TestIntDefault(t *testing.T) {
+	testcontext := ldcontext.New("__test__")
+
+	require.Equal(t, 0, Int(&testcontext, "anyflag"))
+}
+
+func TestFloat64Default(t *testing.T) {
+	testcontext := ldcontext.New("__test__")
+
+	require.Equal(t, 0.0, Float64(&testcontext, "anyflag"))
+}
+
 func TestStringDefault(t *testing.T) {
 	testcontext := ldcontext.New("__test__")
 

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -35,3 +35,9 @@ func TestKillSwitchDefault(t *testing.T) {
 func TestKillSwitchSystemDefault(t *testing.T) {
 	require.True(t, KillSwitchSystem("anyflag"))
 }
+
+func TestStringDefault(t *testing.T) {
+	testcontext := ldcontext.New("__test__")
+
+	require.Equal(t, "", String(&testcontext, "anyflag"))
+}


### PR DESCRIPTION
The `flags` package currently supports Boolean feature flags. This PR adds support for multivariate flags for `int`, `float64`, and `string` value types.

From [LaunchDarkly's documentation](https://docs.launchdarkly.com/home/creating-flags/variations#understanding-flag-types):

> ### Understanding flag types
> LaunchDarkly supports boolean and multivariate flags. On the Variations tab, you can add, edit, or delete variations of existing flags:
>
> * Boolean flags have two variations: true or false.
> * Multivariate flags can have more than two variations. The allowed variations depend on the type of flag. Multivariate flag types are strings, numbers, and JSON. To learn more, read [Understanding multivariate flags](https://docs.launchdarkly.com/home/creating-flags/variations/#understanding-multivariate-flags).
