### PR TITLE
Add FlagBlueGreen to conventionalise blue-green rollouts

### DIFF
--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +21,13 @@ func TestFlagDefaultNilContext(t *testing.T) {
 	Init("")
 
 	require.False(t, Flag(testcontext, "anyflag"))
+}
+
+func TestFlagBlueGreenDefault(t *testing.T) {
+	testcontext := ldcontext.New("__test__")
+
+	assert.Equal(t, FlagBlueGreen(&testcontext, "anyflag", ResultBlue), ResultBlue)
+	assert.Equal(t, FlagBlueGreen(&testcontext, "anyflag", ResultGreen), ResultGreen)
 }
 
 func TestFlagSystemDefault(t *testing.T) {


### PR DESCRIPTION
This exposes what is essentially a boolean flag with a default, but with names and conventions about how boolean values map to those names so that it can work the same way everywhere we use it.

In code this would look like:

```golang
cogRolloutDefault := flags.ResultGreen

if flags.FlagBlueGreen(&flagContext, "cog-rollout", cogRolloutDefault) == flags.ResultBlue {
  cogVersion = cogVersionBlue
} else {
  cogVersion = cogVersionGreen
}
```

Once the rollout is complete and stable in the "blue" state, the operator would update the value of cogRolloutDefault to be `flags.ResultBlue`.