### PR TITLE
Rename FlagBlueGreen to FlagBlueYellow

### DIFF
--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -23,11 +23,11 @@ func TestFlagDefaultNilContext(t *testing.T) {
 	require.False(t, Flag(testcontext, "anyflag"))
 }
 
-func TestFlagBlueGreenDefault(t *testing.T) {
+func TestFlagBlueYellowDefault(t *testing.T) {
 	testcontext := ldcontext.New("__test__")
 
-	assert.Equal(t, FlagBlueGreen(&testcontext, "anyflag", ResultBlue), ResultBlue)
-	assert.Equal(t, FlagBlueGreen(&testcontext, "anyflag", ResultGreen), ResultGreen)
+	assert.Equal(t, FlagBlueYellow(&testcontext, "anyflag", ResultBlue), ResultBlue)
+	assert.Equal(t, FlagBlueYellow(&testcontext, "anyflag", ResultYellow), ResultYellow)
 }
 
 func TestFlagSystemDefault(t *testing.T) {


### PR DESCRIPTION
As described in more detail in the comments, this superficially idiosyncratic renaming makes it easier to map the values to the variations in LaunchDarkly, and emphasises the underlying implementation of this code.

(Prompted by discussion with @evilstreak.)