### PR TITLE
Add DroppedDataProcessor to warn about dropped data

### DIFF
--- a/telemetry/processors.go
+++ b/telemetry/processors.go
@@ -5,7 +5,49 @@ import (
 
 	"github.com/replicate/go/telemetry/semconv"
 	"go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/zap"
 )
+
+// Check DroppedDataProcessor implements SpanProcessor
+var _ trace.SpanProcessor = new(DroppedDataProcessor)
+
+// DroppedDataProcessor logs warnings when spans are dropping data due to
+// attribute/event/link count limits.
+//
+// See the various environment variables that control span limits at
+// https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits
+type DroppedDataProcessor struct {
+	Next trace.SpanProcessor
+}
+
+func (p *DroppedDataProcessor) OnStart(parent context.Context, s trace.ReadWriteSpan) {
+	p.Next.OnStart(parent, s)
+}
+
+func (p *DroppedDataProcessor) OnEnd(s trace.ReadOnlySpan) {
+	if s.DroppedAttributes() > 0 || s.DroppedLinks() > 0 || s.DroppedEvents() > 0 {
+		sc := s.SpanContext()
+		// TODO: we might in future want to throttle the rate at which we emit this
+		// warning, as this could get very chatty indeed.
+		logger.Warn(
+			"span data dropped due to limits",
+			zap.Int("dropped_attributes", s.DroppedAttributes()),
+			zap.Int("dropped_links", s.DroppedLinks()),
+			zap.Int("dropped_events", s.DroppedEvents()),
+			zap.String("trace_id", sc.TraceID().String()),
+			zap.String("span_id", sc.SpanID().String()),
+		)
+	}
+	p.Next.OnEnd(s)
+}
+
+func (p *DroppedDataProcessor) Shutdown(ctx context.Context) error {
+	return p.Next.Shutdown(ctx)
+}
+
+func (p *DroppedDataProcessor) ForceFlush(ctx context.Context) error {
+	return p.Next.ForceFlush(ctx)
+}
 
 // Check TraceOptionsProcessor implements SpanProcessor
 var _ trace.SpanProcessor = new(TraceOptionsProcessor)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -88,7 +88,10 @@ func createTracerProvider(ctx context.Context) (*sdktrace.TracerProvider, error)
 		return nil, fmt.Errorf("failed to merge resources: %w", err)
 	}
 
-	sp := &TraceOptionsProcessor{Next: sdktrace.NewBatchSpanProcessor(exp)}
+	var sp sdktrace.SpanProcessor
+	sp = sdktrace.NewBatchSpanProcessor(exp)
+	sp = &DroppedDataProcessor{Next: sp} // this should remain next-to-last in the chain
+	sp = &TraceOptionsProcessor{Next: sp}
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sp), sdktrace.WithResource(rsrc))
 
 	return tp, nil


### PR DESCRIPTION
By default, attributes/events/links are dropped silently when span limits are exceeded. This adds a SpanProcessor which will log a warning when this occurs instead.

There is a risk that this will create performance issues when data starts to be dropped, but implementing throttling right now seems like overkill.