### PR TITLE
Add uuid tool for generating timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ Standard OpenTelemetry configuration and tracer creation.
 
 A convention for retrieving service version from the environment.
 
+## Tools
+
+The repository also contains a `uuid` command that can be used to generate a list
+of uuids using the `uuid` package.
+
+```bash
+% go run ./cmd/uuid/main.go
+> 018d3855-24f0-7531-84b4-4e88f13bab70
+% go run ./cmd/uuid/main.go -timestamps
+> 018d3855-24f0-7531-84b4-4e88f13bab70 2024-01-23T21:58:40.624Z
+% go run ./cmd/uuid/main.go -count 5 -timestamps
+> 018d3855-24f0-7531-84b4-4e88f13bab70 2024-01-23T21:58:40.624Z
+> 018d3855-24f1-7b1e-be24-4ce73f77d3bf 2024-01-23T21:58:40.625Z
+> 018d3855-24f1-7b33-8b7b-50e5e535b510 2024-01-23T21:58:40.625Z
+> 018d3855-24f1-75d7-abb1-0db1ac9ac285 2024-01-23T21:58:40.625Z
+> 018d3855-24f1-78fc-a1ce-a81e26b3fbe8 2024-01-23T21:58:40.625Z
+```
+
 ## Development
 
 You can run the build, check the tests, lint the code, and run a formatter using

--- a/cmd/uuid7/main.go
+++ b/cmd/uuid7/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/replicate/go/uuid"
+)
+
+func main() {
+	count := flag.Int("count", 1, "number of uuids to create (default: 1)")
+	timestamps := flag.Bool("timestamps", false, "include timestamp in column (default: false)")
+
+	flag.Parse()
+
+	if *count < 0 {
+		fmt.Println("count cannot be less than 0")
+		os.Exit(1)
+	}
+
+	for i := 1; i <= *count; i++ {
+		u, err := uuid.NewV7()
+		if err != nil {
+			fmt.Println("error creating uuid: %w", err)
+			os.Exit(1)
+		}
+
+		ts, err := uuid.TimeFromV7(u)
+		if err != nil {
+			fmt.Println("error extracting timestamp: %w", err)
+			os.Exit(1)
+		}
+
+		if *timestamps {
+			fmt.Println(u, ts.Format(time.RFC3339Nano))
+		} else {
+			fmt.Println(u)
+		}
+	}
+}


### PR DESCRIPTION
This can be used to generate uuids for use in other codebases.

Usage:

```command
% go run ./cmd/uuid/main.go
> 018d3855-24f0-7531-84b4-4e88f13bab70
% go run ./cmd/uuid/main.go -timestamps
> 018d3855-24f0-7531-84b4-4e88f13bab70 2024-01-23T21:58:40.624Z
% go run ./cmd/uuid/main.go -count 5 -timestamps
> 018d3855-24f0-7531-84b4-4e88f13bab70 2024-01-23T21:58:40.624Z
> 018d3855-24f1-7b1e-be24-4ce73f77d3bf 2024-01-23T21:58:40.625Z
> 018d3855-24f1-7b33-8b7b-50e5e535b510 2024-01-23T21:58:40.625Z
> 018d3855-24f1-75d7-abb1-0db1ac9ac285 2024-01-23T21:58:40.625Z
> 018d3855-24f1-78fc-a1ce-a81e26b3fbe8 2024-01-23T21:58:40.625Z
```