### PR TITLE
Add support for negative caching to cache.Cache

### DIFF
--- a/cache/options.go
+++ b/cache/options.go
@@ -1,0 +1,27 @@
+package cache
+
+import "time"
+
+type Option interface {
+	apply(*cacheOptions)
+}
+
+type cacheOptions struct {
+	Fresh    time.Duration
+	Stale    time.Duration
+	Negative time.Duration
+}
+
+type optionFunc func(*cacheOptions)
+
+func (fn optionFunc) apply(opts *cacheOptions) {
+	fn(opts)
+}
+
+// WithNegativeCaching configures the cache to allow caching of a negative
+// ("does not exist") result for up to the specified duration.
+func WithNegativeCaching(duration time.Duration) Option {
+	return optionFunc(func(opts *cacheOptions) {
+		opts.Negative = duration
+	})
+}


### PR DESCRIPTION
This commit adds support for negative caching, that is: caching the non-existence of a specific key. This can help to reduce the cost of cache misses when a client is repeatedly requesting a non-existent object, and may also help mitigate denial of service attacks which target the relatively expensive cache fill operation.

The change is backwards compatible with the existing interface for NewCache through the magic of functional options. Negative caching is disabled by default, but can be enabled by specifying a `WithNegativeCaching` option at initialization:

```golang
fresh := 30 * time.Second
stale := 10 * time.Minute
negative := 10 * time.Second

c := cache.NewCache[User](redis, "user", fresh, stale, cache.WithNegativeCaching(negative))
```

To use negative caching, the cache fetcher function must return a sentinel error value, `cache.ErrDoesNotExist`. This is also the error that will be returned for a negative result. Clients should use `errors.Is(err, cache.ErrDoesNotExist)` to identify a negative result.