### PR TITLE
Add a telemetry.Attributes type

### DIFF
--- a/telemetry/attributes.go
+++ b/telemetry/attributes.go
@@ -1,0 +1,166 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var (
+	ErrUnsupportedValue      = fmt.Errorf("unsupported value")
+	ErrUnsupportedSliceValue = fmt.Errorf("%w: slice attributes may contain only one type", ErrUnsupportedValue)
+)
+
+// Attributes is a wrapper around a slice of attribute.KeyValue values which
+// serializes to and from a simple JSON dictionary, handling type validation and
+// ensuring that JSON numbers are upcast to the appropriate types in the
+// attributes (int64 if possible, float64 otherwise).
+type Attributes []attribute.KeyValue
+
+func (as Attributes) AsSlice() []attribute.KeyValue {
+	return []attribute.KeyValue(as)
+}
+
+func (as Attributes) MarshalJSON() ([]byte, error) {
+	attrMap := make(map[string]any)
+	for _, a := range as {
+		attrMap[string(a.Key)] = a.Value.AsInterface()
+	}
+	return json.Marshal(attrMap)
+}
+
+func (as *Attributes) UnmarshalJSON(b []byte) error {
+	var attrMap map[string]any
+
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber() // read JSON numbers into json.Number so we can distinguish int/float
+
+	if err := d.Decode(&attrMap); err != nil {
+		return err
+	}
+
+	kvs := make([]attribute.KeyValue, 0, len(attrMap))
+
+	for k, v := range attrMap {
+		key := attribute.Key(k)
+		value, err := getValue(v)
+		if errors.Is(err, ErrUnsupportedValue) {
+			logger.Sugar().Warnw("skipping unsupported attribute value", "key", k, "error", err)
+			continue
+		} else if err != nil {
+			return err
+		}
+		kvs = append(kvs, attribute.KeyValue{Key: key, Value: value})
+	}
+
+	*as = kvs
+
+	return nil
+}
+
+func getValue(value any) (attribute.Value, error) {
+	switch v := value.(type) {
+	case json.Number:
+		if asInt64, err := v.Int64(); err == nil {
+			return attribute.Int64Value(asInt64), nil
+		}
+		if asFloat64, err := v.Float64(); err == nil {
+			return attribute.Float64Value(asFloat64), nil
+		} else {
+			return attribute.Value{}, err
+		}
+	case bool:
+		return attribute.BoolValue(v), nil
+	case string:
+		return attribute.StringValue(v), nil
+	case []any:
+		return getSliceValue(v)
+	default:
+		return attribute.Value{}, ErrUnsupportedValue
+	}
+}
+
+func getSliceValue(values []any) (attribute.Value, error) {
+	if len(values) == 0 {
+		// We have no type information, we arbitrarily decide it's a string slice.
+		return attribute.StringSliceValue([]string{}), nil
+	}
+
+	var isFloat bool
+
+	if _, ok := values[0].(json.Number); ok {
+		// If it's a json.Number, then we only map to int64 if *all* the values can
+		// be parsed as ints.
+		for _, v := range values {
+			asNumber, ok := v.(json.Number)
+			if !ok {
+				return attribute.Value{}, ErrUnsupportedSliceValue
+			}
+			if _, err := asNumber.Int64(); err != nil {
+				isFloat = true
+				break
+			}
+		}
+	}
+
+	switch values[0].(type) {
+	case json.Number:
+		if isFloat {
+			s := make([]float64, len(values))
+			for i, v := range values {
+				asNumber, ok := v.(json.Number)
+				if !ok {
+					return attribute.Value{}, ErrUnsupportedSliceValue
+				}
+				asFloat64, err := asNumber.Float64()
+				if err != nil {
+					return attribute.Value{}, err
+				}
+				s[i] = asFloat64
+			}
+			return attribute.Float64SliceValue(s), nil
+		}
+		s := make([]int64, len(values))
+		for i, v := range values {
+			asNumber, ok := v.(json.Number)
+			if !ok {
+				return attribute.Value{}, ErrUnsupportedSliceValue
+			}
+			asInt64, err := asNumber.Int64()
+			if err != nil {
+				return attribute.Value{}, err
+			}
+			s[i] = asInt64
+		}
+		return attribute.Int64SliceValue(s), nil
+	case bool:
+		s, err := createTypedSlice[bool](values)
+		if err != nil {
+			return attribute.Value{}, err
+		}
+		return attribute.BoolSliceValue(s), nil
+	case string:
+		s, err := createTypedSlice[string](values)
+		if err != nil {
+			return attribute.Value{}, err
+		}
+		return attribute.StringSliceValue(s), nil
+	default:
+		return attribute.Value{}, ErrUnsupportedValue
+	}
+}
+
+func createTypedSlice[T any](values []any) ([]T, error) {
+	s := make([]T, len(values))
+	for i, v := range values {
+		asT, ok := v.(T)
+		if !ok {
+			return nil, ErrUnsupportedSliceValue
+		}
+		s[i] = asT
+	}
+	return s, nil
+}

--- a/telemetry/attributes_test.go
+++ b/telemetry/attributes_test.go
@@ -1,0 +1,169 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var attributeTestCases = []struct {
+	Name string
+	JSON string
+	KVs  []attribute.KeyValue
+}{
+	{
+		Name: "bool",
+		JSON: `{"enabled": true, "is_this_thing_on": false}`,
+		KVs: []attribute.KeyValue{
+			attribute.Bool("enabled", true),
+			attribute.Bool("is_this_thing_on", false),
+		},
+	},
+	{
+		Name: "int64",
+		JSON: `{"age": 42, "zero": 0, "bigger_than_int32": 2147483650}`,
+		KVs: []attribute.KeyValue{
+			attribute.Int("age", 42),
+			attribute.Int("zero", 0),
+			attribute.Int("bigger_than_int32", 2147483650),
+		},
+	},
+	{
+		Name: "float64",
+		JSON: `{"pi": 3.141592653589793, "negative": -1.234567}`,
+		KVs: []attribute.KeyValue{
+			attribute.Float64("pi", 3.141592653589793),
+			attribute.Float64("negative", -1.234567),
+		},
+	},
+	{
+		Name: "string",
+		JSON: `{"name": "Boz", "empty": ""}`,
+		KVs: []attribute.KeyValue{
+			attribute.String("name", "Boz"),
+			attribute.String("empty", ""),
+		},
+	},
+	{
+		Name: "bool slice",
+		JSON: `{"flags": [true, false, false, true]}`,
+		KVs: []attribute.KeyValue{
+			attribute.BoolSlice("flags", []bool{true, false, false, true}),
+		},
+	},
+	{
+		Name: "int64 slice",
+		JSON: `{"lotto": [12, 17, 46]}`,
+		KVs: []attribute.KeyValue{
+			attribute.IntSlice("lotto", []int{12, 17, 46}),
+		},
+	},
+	{
+		Name: "float64 slice",
+		JSON: `{"coordinates": [51.477928, -0.001545], "mixed": [1, 2, 3, 4.5]}`,
+		KVs: []attribute.KeyValue{
+			attribute.Float64Slice("coordinates", []float64{51.477928, -0.001545}),
+			attribute.Float64Slice("mixed", []float64{1, 2, 3, 4.5}),
+		},
+	},
+	{
+		Name: "string slice",
+		JSON: `{"hobbies": ["gardening", "fishing"], "empty": []}`,
+		KVs: []attribute.KeyValue{
+			attribute.StringSlice("hobbies", []string{"gardening", "fishing"}),
+			attribute.StringSlice("empty", []string{}),
+		},
+	},
+}
+
+func TestAttributesMarshalFunctional(t *testing.T) {
+	x := struct {
+		Attributes Attributes `json:"my_attrs"`
+	}{
+		Attributes: Attributes([]attribute.KeyValue{
+			attribute.Bool("enabled", true),
+			attribute.Int("age", 42),
+			attribute.Float64("pi", 3.141592653589793),
+			attribute.String("name", "Florp"),
+		}),
+	}
+
+	out, err := json.Marshal(x)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"my_attrs": {
+			"enabled": true,
+			"age": 42,
+			"pi": 3.141592653589793,
+			"name": "Florp"
+		}
+	}`, string(out))
+}
+
+func TestAttributesMarshal(t *testing.T) {
+	for _, tc := range attributeTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			out, err := json.Marshal(Attributes(tc.KVs))
+			require.NoError(t, err)
+
+			assert.JSONEq(t, tc.JSON, string(out))
+		})
+	}
+}
+
+func TestAttributesUnmarshal(t *testing.T) {
+	for _, tc := range attributeTestCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var attrs Attributes
+
+			err := json.Unmarshal([]byte(tc.JSON), &attrs)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, tc.KVs, attrs)
+		})
+	}
+}
+
+// For now, we want to ignore rather than choke on invalid types.
+func TestAttributesUnmarshalInvalidTypes(t *testing.T) {
+	testCases := []struct {
+		Name string
+		JSON string
+	}{
+		{
+			Name: "null",
+			JSON: `{"null": null}`,
+		},
+		{
+			Name: "empty map",
+			JSON: `{"map": {}}`,
+		},
+		{
+			Name: "map with entries",
+			JSON: `{"map": {"name": "Chigozie"}}`,
+		},
+		{
+			Name: "mixed type slice",
+			JSON: `{"mixedup": [123, "eatmyshorts"]}`,
+		},
+		{
+			Name: "nested slice",
+			JSON: `{"nested": [[1], [2], [3]]}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var attrs Attributes
+
+			err := json.Unmarshal([]byte(tc.JSON), &attrs)
+			require.NoError(t, err)
+
+			assert.Empty(t, attrs)
+		})
+	}
+}


### PR DESCRIPTION
This type allows the serialization and deserialization of a set of OTel span attributes from JSON, handling type validation and upcasting for that scenario.