### PR TITLE
Steps toward an RFC 9241 HTTP Message Signatures implementation

### DIFF
--- a/http/signing/components.go
+++ b/http/signing/components.go
@@ -1,0 +1,272 @@
+package signing
+
+import (
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"regexp"
+	"strings"
+)
+
+const (
+	// sf-string from [RFC 8941]
+	//
+	//     sf-string = DQUOTE *chr DQUOTE
+	//     chr       = unescaped / escaped
+	//     unescaped = %x20-21 / %x23-5B / %x5D-7E
+	//     escaped   = "\" ( DQUOTE / "\" )
+	//
+	// [RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941
+	reSFString = `"(?:[\x20-\x21\x23-\x5B\x5D-\x7E]|\\"|\\\\)*"`
+
+	// We don't need to implement a full scanner for parameters, as only a small
+	// subset of parameters are currently permitted by [RFC 9421 Section 6.5.2].
+	//
+	// [RFC 9421 Section 6.5.2]: https://www.rfc-editor.org/rfc/rfc9421#section-6.5.2
+	reComponentParameter = `(?:(?:sf|bs|tr|req|key=` + reSFString + `|name=` + reSFString + `))`
+)
+
+var (
+	// The ABNF for component identifiers is as follows
+	//
+	//     component-identifier = component-name parameters
+	//     component-name = sf-string
+	//
+	pattComponentIdentifier = regexp.MustCompile(
+		`\A` +
+			// component-name = sf-string
+			`(` + reSFString + `)` +
+			// parameters = *( ";" parameter )
+			`((?:;` + reComponentParameter + `)*)` +
+			`\z`,
+	)
+	pattComponentParameter = regexp.MustCompile(`;` + reComponentParameter)
+
+	// Obsolete line folding from [RFC 7230]
+	//
+	// [RFC 7230]: https://www.rfc-editor.org/rfc/rfc7230
+	pattObsFold = regexp.MustCompile(`\r\n[ \t]+`)
+)
+
+var derivedComponents = map[string]bool{
+	"@method":         true,
+	"@target-uri":     true,
+	"@authority":      true,
+	"@scheme":         true,
+	"@request-target": true,
+	"@path":           true,
+	"@query":          true,
+	"@query-param":    true,
+	"@status":         true,
+}
+
+type ValidatedComponents []component
+
+func (cs ValidatedComponents) Base(req *http.Request) (string, error) {
+	var b strings.Builder
+	for _, c := range cs {
+		b.WriteString(c.Identifier())
+		b.WriteRune(':')
+		b.WriteRune(' ')
+		v, err := c.Value(req)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(v)
+		b.WriteRune('\n')
+	}
+	return b.String(), nil
+}
+
+func (cs ValidatedComponents) Identifiers() []string {
+	ids := make([]string, len(cs))
+	for i, c := range cs {
+		ids[i] = c.Identifier()
+	}
+	return ids
+}
+
+type component interface {
+	Identifier() string
+	Value(req *http.Request) (string, error)
+}
+
+type param struct {
+	Key   string
+	Value string
+}
+
+func Components(spec []string) (ValidatedComponents, error) {
+	cs := make([]component, len(spec))
+	for i, s := range spec {
+		c, err := validateComponent(s)
+		if err != nil {
+			return nil, err
+		}
+		cs[i] = c
+	}
+	return cs, nil
+}
+
+func MustComponents(spec []string) ValidatedComponents {
+	cs, err := Components(spec)
+	if err != nil {
+		panic(err)
+	}
+	return cs
+}
+
+func validateComponent(s string) (component, error) {
+	matches := pattComponentIdentifier.FindStringSubmatch(s)
+	if len(matches) != 3 {
+		return nil, fmt.Errorf("%w: malformed identifier %q", ErrInvalidComponent, s)
+	}
+
+	nameStr := matches[1]
+	paramStr := matches[2]
+
+	var params []param
+
+	// Validate parameters
+	if paramStr != "" {
+		paramMatches := pattComponentParameter.FindAllString(paramStr, -1)
+
+		paramKeys := make(map[string]bool)
+		params = make([]param, len(paramMatches))
+
+		for i, p := range paramMatches {
+			pk, pv, _ := strings.Cut(p[1:], "=")
+			if _, ok := paramKeys[pk]; ok {
+				return nil, fmt.Errorf("%w: repeated parameter %s for %s is not permitted", ErrInvalidComponent, pk, nameStr)
+			}
+
+			paramKeys[pk] = true
+			params[i] = param{Key: pk, Value: pv}
+		}
+
+		// TODO: validate cross-compatibility of parameters
+		// TODO: validate that `req` parameter is not supplied
+	}
+
+	// It's not clear whether this is actually required by the spec, but it's hard
+	// to see a valid case for providing a blank component name.
+	if nameStr == `""` {
+		return nil, fmt.Errorf("%w: component names may not be blank", ErrInvalidComponent)
+	}
+
+	// Remove outer quotes
+	name := nameStr[1 : len(nameStr)-1]
+
+	if name[0] == '@' {
+		if _, ok := derivedComponents[name]; !ok {
+			return nil, fmt.Errorf("%w: unknown derived component name %s", ErrInvalidComponent, name)
+		}
+		return derivedComponent{
+			Name:   name,
+			Params: params,
+		}, nil
+	}
+
+	return fieldComponent{
+		Name:   name,
+		Params: params,
+	}, nil
+}
+
+type derivedComponent struct {
+	Name   string
+	Params []param
+}
+
+func (c derivedComponent) Identifier() string {
+	return makeIdentifier(c.Name, c.Params)
+}
+
+func (c derivedComponent) Value(req *http.Request) (string, error) {
+	// For now, treat any parameters as ErrNotImplemented.
+	if len(c.Params) > 0 {
+		return "", fmt.Errorf("%w: parameters are not yet supported (field %s)", ErrNotImplemented, c.Name)
+	}
+
+	switch c.Name {
+	case "@method":
+		return req.Method, nil
+	case "@target-uri":
+		return req.URL.String(), nil
+	case "@authority":
+		return req.Host, nil
+	case "@scheme":
+		return req.URL.Scheme, nil
+	case "@request-target":
+		return req.URL.RequestURI(), nil
+	case "@path":
+		result := req.URL.EscapedPath()
+		if result == "" {
+			result = "/"
+		}
+		return result, nil
+	case "@query":
+		return req.URL.RawQuery, nil
+	case "@query-param":
+		return "", fmt.Errorf("%w: @query-param is not yet implemented", ErrNotImplemented)
+	default:
+		return "", fmt.Errorf("%w: unknown derived component %s", ErrSigningFailure, c.Name)
+	}
+}
+
+type fieldComponent struct {
+	Name   string
+	Params []param
+}
+
+func (c fieldComponent) Identifier() string {
+	return makeIdentifier(c.Name, c.Params)
+}
+
+func (c fieldComponent) Value(req *http.Request) (string, error) {
+	key := textproto.CanonicalMIMEHeaderKey(c.Name)
+	vals := req.Header[key]
+
+	// For now, treat any parameters as ErrNotImplemented.
+	if len(c.Params) > 0 {
+		return "", fmt.Errorf("%w: parameters are not yet supported (field %s)", ErrNotImplemented, c.Name)
+	}
+
+	// If the field has been requested for signing and there are no values
+	// available, signing must fail.
+	if len(vals) == 0 {
+		return "", fmt.Errorf("%w: request lacks requested field %s", ErrSigningFailure, c.Name)
+	}
+
+	canonicalVals := make([]string, len(vals))
+	for i, v := range vals {
+		// Strip leading and trailing whitespace from each item in the list.
+		s := strings.TrimSpace(v)
+		// Remove any obsolete line folding within the line, and replace it with a
+		// single space (" "), as discussed in [Section 5.2 of HTTP/1.1].
+		//
+		// [Section 5.2 of HTTP/1.1]: https://rfc-editor.org/rfc/rfc9112#section-5.2
+		s = pattObsFold.ReplaceAllString(v, " ")
+
+		canonicalVals[i] = s
+	}
+	// Concatenate the list of values with a single comma (",") and a single space
+	// (" ") between each item.
+	return strings.Join(canonicalVals, ", "), nil
+}
+
+func makeIdentifier(name string, params []param) string {
+	var b strings.Builder
+	b.WriteRune('"')
+	b.WriteString(name)
+	b.WriteRune('"')
+	for _, p := range params {
+		b.WriteRune(';')
+		b.WriteString(p.Key)
+		if p.Value != "" {
+			b.WriteRune('=')
+			b.WriteString(p.Value)
+		}
+	}
+	return b.String()
+}

--- a/http/signing/components_test.go
+++ b/http/signing/components_test.go
@@ -1,0 +1,237 @@
+package signing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComponents(t *testing.T) {
+	testcases := []struct {
+		Name       string
+		Spec       []string
+		Components ValidatedComponents
+		Err        error
+	}{
+		{
+			Name:       "empty spec",
+			Spec:       []string{},
+			Components: ValidatedComponents{},
+			Err:        nil,
+		},
+		{
+			Name: "single field component",
+			Spec: []string{`"content-type"`},
+			Components: ValidatedComponents{
+				fieldComponent{Name: "content-type"},
+			},
+			Err: nil,
+		},
+		{
+			Name: "single field component with params",
+			Spec: []string{`"content-type";sf`},
+			Components: ValidatedComponents{
+				fieldComponent{
+					Name:   "content-type",
+					Params: []param{{Key: "sf"}},
+				},
+			},
+			Err: nil,
+		},
+		{
+			Name: "multiple field components",
+			Spec: []string{`"content-type";sf`, `"content-encoding"`},
+			Components: ValidatedComponents{
+				fieldComponent{
+					Name:   "content-type",
+					Params: []param{{Key: "sf"}},
+				},
+				fieldComponent{
+					Name: "content-encoding",
+				},
+			},
+			Err: nil,
+		},
+		{
+			Name: "derived component",
+			Spec: []string{`"@method"`},
+			Components: ValidatedComponents{
+				derivedComponent{
+					Name: "@method",
+				},
+			},
+			Err: nil,
+		},
+		{
+			Name: "mixed components",
+			Spec: []string{
+				`"@authority"`,
+				`"content-type"`,
+				`"@method"`,
+			},
+			Components: ValidatedComponents{
+				derivedComponent{
+					Name: "@authority",
+				},
+				fieldComponent{
+					Name: "content-type",
+				},
+				derivedComponent{
+					Name: "@method",
+				},
+			},
+			Err: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			components, err := Components(tc.Spec)
+			if tc.Err != nil {
+				assert.ErrorIs(t, err, tc.Err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.Components, components)
+			}
+		})
+	}
+}
+
+func TestValidatedComponentsBase(t *testing.T) {
+	testcases := []struct {
+		Name       string
+		Components ValidatedComponents
+		RequestFn  func() *http.Request
+		Expected   string
+		Err        error
+	}{
+		{
+			Name:       "empty components",
+			Components: MustComponents([]string{}),
+			RequestFn: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+				return r
+			},
+			Expected: "",
+		},
+		{
+			Name: "single field component (valid)",
+			Components: MustComponents([]string{
+				`"content-type"`,
+			}),
+			RequestFn: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+				r.Header.Set("Content-Type", "application/json")
+				return r
+			},
+			Expected: `"content-type": application/json` + "\n",
+		},
+		{
+			Name: "single derived component",
+			Components: MustComponents([]string{
+				`"@method"`,
+			}),
+			RequestFn: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodPost, "http://example.com", nil)
+				return r
+			},
+			Expected: `"@method": POST` + "\n",
+		},
+		{
+			Name: "mixed components",
+			Components: MustComponents([]string{
+				`"@method"`,
+				`"content-type"`,
+				`"@path"`,
+			}),
+			RequestFn: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodPost, "http://example.com/animals/giraffes?age=123", nil)
+				r.Header.Set("Content-Type", "application/json")
+				return r
+			},
+			Expected: `"@method": POST` + "\n" +
+				`"content-type": application/json` + "\n" +
+				`"@path": /animals/giraffes` + "\n",
+		},
+		{
+			Name: "unhandled derived component",
+			Components: MustComponents([]string{
+				`"@status"`,
+			}),
+			RequestFn: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodPost, "/envelope/opener", nil)
+				return r
+			},
+			Err: ErrSigningFailure,
+		},
+		{
+			Name: "missing field component",
+			Components: MustComponents([]string{
+				`"content-type"`,
+			}),
+			RequestFn: func() *http.Request {
+				r, _ := http.NewRequest(http.MethodPost, "/envelope/opener", nil)
+				return r
+			},
+			Err: ErrSigningFailure,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			base, err := tc.Components.Base(tc.RequestFn())
+			if tc.Err != nil {
+				assert.ErrorIs(t, err, tc.Err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.Expected, base)
+			}
+		})
+	}
+}
+
+func TestValidatedComponentsIdentifiers(t *testing.T) {
+	testcases := []struct {
+		Name       string
+		Components ValidatedComponents
+		Expected   []string
+	}{
+		{
+			Name:       "empty components",
+			Components: MustComponents([]string{}),
+			Expected:   []string{},
+		},
+		{
+			Name: "single field component",
+			Components: MustComponents([]string{
+				`"content-type"`,
+			}),
+			Expected: []string{`"content-type"`},
+		},
+		{
+			Name: "single derived component",
+			Components: MustComponents([]string{
+				`"@method"`,
+			}),
+			Expected: []string{`"@method"`},
+		},
+		{
+			Name: "mixed components",
+			Components: MustComponents([]string{
+				`"@method"`,
+				`"content-type"`,
+				`"@path"`,
+			}),
+			Expected: []string{`"@method"`, `"content-type"`, `"@path"`},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ids := tc.Components.Identifiers()
+			assert.Equal(t, tc.Expected, ids)
+		})
+	}
+}

--- a/http/signing/errors.go
+++ b/http/signing/errors.go
@@ -1,0 +1,11 @@
+package signing
+
+import "errors"
+
+var (
+	ErrInvalidLabel     = errors.New("invalid signature label")
+	ErrInvalidComponent = errors.New("invalid signature component")
+	ErrSigningFailure   = errors.New("failed to sign request")
+
+	ErrNotImplemented = errors.New("not implemented")
+)

--- a/http/signing/options.go
+++ b/http/signing/options.go
@@ -1,0 +1,68 @@
+package signing
+
+import (
+	"regexp"
+	"time"
+)
+
+type Option interface {
+	apply(*options) error
+}
+
+type options struct {
+	label string
+
+	alg   string
+	keyID string
+	ttl   time.Duration
+}
+
+type optionFunc func(*options) error
+
+func (fn optionFunc) apply(opts *options) error {
+	return fn(opts)
+}
+
+// WithExpiry sets the time-to-live for the signature. This is used to calculate
+// the "expires" parameter.
+//
+// Values of expiry <= 0 will be ignored.
+func WithExpiry(expiry time.Duration) Option {
+	return optionFunc(func(opts *options) error {
+		opts.ttl = expiry
+		return nil
+	})
+}
+
+// WithKeyID sets the "keyid" parameter of the signature.
+func WithKeyID(id string) Option {
+	return optionFunc(func(opts *options) error {
+		opts.keyID = id
+		return nil
+	})
+}
+
+// WithLabel sets the label of the signature as used in the Signature-Input and
+// Signature headers.
+func WithLabel(label string) Option {
+	return optionFunc(func(opts *options) error {
+		// name must be usable as a "param-key" from [RFC 8941]
+		//
+		// [RFC 8941]: https://www.rfc-editor.org/rfc/rfc8941#section-3.1.2
+		if !regexp.MustCompile(`\A[a-z*][a-z0-9_.*-]*\z`).MatchString(label) {
+			return ErrInvalidLabel
+		}
+		opts.label = label
+		return nil
+	})
+}
+
+func makeOptions(opts ...Option) (*options, error) {
+	options := &options{}
+	for _, o := range opts {
+		if err := o.apply(options); err != nil {
+			return nil, err
+		}
+	}
+	return options, nil
+}

--- a/http/signing/signer.go
+++ b/http/signing/signer.go
@@ -1,0 +1,128 @@
+// Package signing implements support for HTTP Message Signatures as defined in
+// [RFC 9241].
+//
+// [RFC 9241]: https://www.rfc-editor.org/rfc/rfc9421.html
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const AlgEd25519 = "ed25519"
+
+type Signer interface {
+	Sign(req *http.Request) (*Signature, error)
+}
+
+type Signature struct {
+	Input     string
+	Signature string
+}
+
+type signer struct {
+	components ValidatedComponents
+	options    *options
+	signFn     func(payload []byte) (signature []byte, err error)
+}
+
+func (s *signer) Sign(req *http.Request) (*Signature, error) {
+	params, payload, err := s.prepare(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.signFn == nil {
+		return nil, fmt.Errorf("%w: improperly configured signer", ErrSigningFailure)
+	}
+	data, err := s.signFn(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.makesig(params, data), nil
+}
+
+func (s *signer) params(ts time.Time) string {
+	var b strings.Builder
+	b.WriteRune('(')
+	b.WriteString(strings.Join(s.components.Identifiers(), " "))
+	b.WriteRune(')')
+
+	b.WriteString(`;created=`)
+	b.WriteString(strconv.FormatInt(ts.Unix(), 10))
+
+	if s.options.ttl > 0 {
+		b.WriteString(`;expires=`)
+		b.WriteString(strconv.FormatInt(ts.Add(s.options.ttl).Unix(), 10))
+	}
+
+	if s.options.keyID != "" {
+		b.WriteString(`;keyid="`)
+		b.WriteString(url.QueryEscape(s.options.keyID))
+		b.WriteString(`"`)
+	}
+
+	if s.options.alg != "" {
+		b.WriteString(`;alg="`)
+		b.WriteString(s.options.alg)
+		b.WriteRune('"')
+	}
+
+	return b.String()
+}
+
+func (s *signer) prepare(req *http.Request) (params string, payload []byte, err error) {
+	var b strings.Builder
+
+	params = s.params(time.Now())
+
+	base, err := s.components.Base(req)
+	if err != nil {
+		return "", []byte{}, err
+	}
+	b.WriteString(base)
+	b.WriteString(`"@signature-params": `)
+	b.WriteString(params)
+
+	return params, []byte(b.String()), nil
+}
+
+func (s *signer) makesig(params string, data []byte) *Signature {
+	sig := base64.StdEncoding.EncodeToString(data)
+
+	label := s.options.label
+	if label == "" {
+		label = "sig"
+	}
+
+	return &Signature{
+		Input:     label + "=" + params,
+		Signature: label + "=:" + sig + ":",
+	}
+}
+
+// NewEd25519Signer creates a new Signer that signs requests with the provided
+// private key.
+func NewEd25519Signer(key ed25519.PrivateKey, components ValidatedComponents, opts ...Option) (Signer, error) {
+	options, err := makeOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+	options.alg = AlgEd25519
+
+	return &signer{
+		components: components,
+		options:    options,
+
+		signFn: func(data []byte) ([]byte, error) {
+			return key.Sign(nil, data, &ed25519.Options{})
+		},
+	}, nil
+}

--- a/http/signing/signer_test.go
+++ b/http/signing/signer_test.go
@@ -1,0 +1,40 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEd25519Signer(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
+	components := MustComponents([]string{
+		`"@method"`,
+		`"@target-uri"`,
+		`"@authority"`,
+	})
+	signer, err := NewEd25519Signer(
+		privateKey,
+		components,
+		WithLabel("default"),
+		WithExpiry(5*time.Minute),
+		WithKeyID("testkey123"),
+	)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("GET", "https://example.com", nil)
+	require.NoError(t, err)
+
+	_, err = signer.Sign(req)
+	require.NoError(t, err)
+
+	// TODO: validate the signature!
+}

--- a/http/signing/transport.go
+++ b/http/signing/transport.go
@@ -1,0 +1,34 @@
+package signing
+
+import "net/http"
+
+// Transport is an implementation of http.RoundTripper that adds request signing
+// headers as defined in RFC 9241.
+type Transport struct {
+	http.RoundTripper
+	Signer
+	SignatureName string
+}
+
+func NewTransport(t http.RoundTripper, s Signer, signame string) *Transport {
+	return &Transport{
+		RoundTripper:  t,
+		Signer:        s,
+		SignatureName: signame,
+	}
+}
+
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// RoundTrip must not modify the original request.
+	req = req.Clone(req.Context())
+
+	sig, err := t.Sign(req)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Signature-Input", sig.Input)
+	req.Header.Add("Signature", sig.Signature)
+
+	return t.RoundTripper.RoundTrip(req)
+}


### PR DESCRIPTION
We want to use request signing to authenticate service-to-service traffic within Replicate. Request signing is an attractive option for a number of reasons. Two important ones:

1. we authenticate individual requests, not a communication channel shared between many requests (looking at you, mTLS)
2. we have access to authentication data, signature parameters, etc., at the HTTP layer, which makes enforcing per-endpoint requirements much easier

This commit starts to lay the groundwork for an implementation of HTTP Message Signatures in compliance with [RFC 9241](https://www.rfc-editor.org/rfc/rfc9421). This is by no means a complete implementation of the spec, but it should already cover almost everything needed for deployment at Replicate.

Notably, there is currently no support for signing responses, only requests.

Currently only signing is implemented. Verification code will initially only be needed in Python, although we'll likely want to add it here so we can more effectively test this.