### PR TITLE
Don't export metrics via OTLP

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -25,12 +25,12 @@ func init() {
 }
 
 func Shutdown(ctx context.Context) error {
-	if tp, ok := otel.GetTracerProvider().(*trace.TracerProvider); ok {
+	if tp, ok := otel.GetTracerProvider().(*trace.TracerProvider); ok && tp != nil {
 		if err := tp.Shutdown(ctx); err != nil {
 			return err
 		}
 	}
-	if mp, ok := otel.GetMeterProvider().(*metric.MeterProvider); ok {
+	if mp, ok := otel.GetMeterProvider().(*metric.MeterProvider); ok && mp != nil {
 		if err := mp.Shutdown(ctx); err != nil {
 			return err
 		}

--- a/telemetry/trace_test.go
+++ b/telemetry/trace_test.go
@@ -16,6 +16,7 @@ func TestInit(t *testing.T) {
 	// This is usually called by package init, but here we call it explicitly so
 	// the lack of an OTEL_EXPORTER_OTLP_ENDPOINT doesn't cause us to skip it.
 	configureTracerProvider()
+	configureMeterProvider(false)
 
 	tp := otel.GetTracerProvider()
 	assert.IsType(t, &sdktrace.TracerProvider{}, tp)
@@ -28,6 +29,7 @@ func TestTraceContextFromContext(t *testing.T) {
 	// This is usually called by package init, but here we call it explicitly so
 	// the lack of an OTEL_EXPORTER_OTLP_ENDPOINT doesn't cause us to skip it.
 	configureTracerProvider()
+	configureMeterProvider(false)
 
 	ctx := context.Background()
 	ctx, span := Tracer("test", "trace_context_test").Start(ctx, "my-span")


### PR DESCRIPTION
This currently generates [an awful lot of events](https://ui.honeycomb.io/replicate/environments/production/datasets/unknown_metrics/usage/result/hxKTYK7ePwm) for Honeycomb/Refinery, and it's not clear that we need it as we're sorting out Grafana and Prometheus.

For now, just turn this off.