### PR TITLE
Pipeline the calls involved in cache set

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -72,9 +72,11 @@ func (m mockWrapper) ExpectCacheFill(key string, value any) {
 	if err != nil {
 		panic(err)
 	}
+	m.ExpectTxPipeline()
 	m.ExpectDel("cache:negative:" + m.name + ":" + key).SetVal(0)
 	m.ExpectSet("cache:data:"+m.name+":"+key, string(data), m.stale).SetVal("OK")
 	m.ExpectSet("cache:fresh:"+m.name+":"+key, 1, m.fresh).SetVal("OK")
+	m.ExpectTxPipelineExec()
 }
 
 func (m mockWrapper) ExpectCacheFillNegative(key string) {


### PR DESCRIPTION
This makes these calls both pipelined (all executed with a single network call) and transactional (all must succeed or none will).