### PR TITLE
Set expiry on meta keys when touching them

### DIFF
--- a/queue/client_test.go
+++ b/queue/client_test.go
@@ -217,6 +217,10 @@ func TestClientReadLegacyStreamIntegration(t *testing.T) {
 		msgs[msg.Values["idx"].(string)] = struct{}{}
 	}
 
+	ttl, err := rdb.TTL(ctx, "myqueue:meta").Result()
+	require.NoError(t, err)
+	assert.Greater(t, ttl, 23*time.Hour)
+
 	assert.Len(t, msgs, 50)
 }
 

--- a/queue/read.lua
+++ b/queue/read.lua
@@ -84,6 +84,7 @@ for idx = 0, streams do
     local reply = checkstream(base)
     if reply then
       redis.call('HSET', key_meta, 'offset', (offset + idx + 1) % streams)
+      redis.call('EXPIRE', key_meta, ttl)
       return reply
     end
   end
@@ -91,6 +92,7 @@ for idx = 0, streams do
   local reply = checkstream(base .. ':s' .. streamid)
   if reply then
     redis.call('HSET', key_meta, 'offset', (offset + idx + 1) % streams)
+    redis.call('EXPIRE', key_meta, ttl)
     return reply
   end
 end

--- a/queue/write.lua
+++ b/queue/write.lua
@@ -102,7 +102,7 @@ local id = redis.call('XADD', key_stream, '*', unpack(fields))
 -- Add a notification to the notifications stream
 redis.call('XADD', key_notifications, 'MAXLEN', '1', '*', 's', selected_sid)
 
--- Set expiry on all selected streams + meta key
+-- Set expiry on selected stream + meta/notifications keys
 redis.call('EXPIRE', key_stream, ttl)
 redis.call('EXPIRE', key_meta, ttl)
 redis.call('EXPIRE', key_notifications, ttl)


### PR DESCRIPTION
Even in the read command, we need to ensure that a TTL is set on the meta key when we write to it.