### PR TITLE
Support LOG_FILE env var

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -45,6 +45,11 @@ func NewConfig() zap.Config {
 		}
 	}
 
+	logFile := os.Getenv("LOG_FILE")
+	if logFile != "" {
+		config.OutputPaths = []string{logFile}
+	}
+
 	return config
 }
 


### PR DESCRIPTION
We want to run FUSE RPC client in host name space and survive mounter (client management service) restart, so we have to log into a file instead of pipe back to the parent process.