### PR TITLE
Allow preferring a specified stream in queue.Read

### DIFF
--- a/queue/types.go
+++ b/queue/types.go
@@ -24,10 +24,11 @@ type WriteArgs struct {
 }
 
 type ReadArgs struct {
-	Name     string        // queue name
-	Group    string        // consumer group name
-	Consumer string        // consumer ID
-	Block    time.Duration // total blocking time
+	Name         string        // queue name
+	Group        string        // consumer group name
+	Consumer     string        // consumer ID
+	PreferStream string        // if specified, prefer reading from this stream
+	Block        time.Duration // total blocking time
 }
 
 type Message struct {


### PR DESCRIPTION
By default the queue client's Read method uses an approach to reading multi-stream queues that attempts to share the consumer resources fairly between all the streams.

This commit adds a PreferStream field to queue.ReadArgs which, if it identifies a valid stream in the queue, is checked in preference to all other streams.

If PreferStream is empty, or no messages can be found in PreferStream within the specified Block time, Read will fall back to checking all other streams in the queue.

The client is expected to keep track of the value of Stream returned in the most recent Message and pass that back in as the value of PreferStream.

This read behavior is most useful in the context of hotswaps, where each stream represents a specific workload (i.e. a specific value of "replicate_weights"). We can create "affinity" between a specific workload and a specific instance (or instances) of director by reading greedily from the same stream as much as possible.
