### PR TITLE
PLAT-604 [queue] create Stats (to replace PendingCount)

### DIFF
--- a/queue/client_test.go
+++ b/queue/client_test.go
@@ -78,9 +78,10 @@ func TestClientIntegration(t *testing.T) {
 		assert.Contains(t, msg.Values, "id")
 		ids[msg.Values["id"].(string)] = struct{}{}
 
-		pendingCount, err := client.PendingCount(ctx, "test", "mygroup")
+		stats, err := client.Stats(ctx, "test", "mygroup")
 		require.NoError(t, err)
-		assert.EqualValues(t, i+1, pendingCount)
+		assert.EqualValues(t, i+1, stats.PendingCount)
+		assert.EqualValues(t, 15, stats.Len)
 	}
 
 	// We should have read all the messages we enqueued

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -48,6 +48,10 @@ var (
 	pendingCountCmd    string
 	pendingCountScript = redis.NewScript(pendingCountCmd)
 
+	//go:embed stats.lua
+	statsCmd    string
+	statsScript = redis.NewScript(statsCmd)
+
 	//go:embed read.lua
 	readCmd    string
 	readScript = redis.NewScript(readCmd)
@@ -62,6 +66,9 @@ func prepare(ctx context.Context, rdb redis.Cmdable) error {
 		return err
 	}
 	if err := pendingCountScript.Load(ctx, rdb).Err(); err != nil {
+		return err
+	}
+	if err := statsScript.Load(ctx, rdb).Err(); err != nil {
 		return err
 	}
 	if err := readScript.Load(ctx, rdb).Err(); err != nil {

--- a/queue/stats.lua
+++ b/queue/stats.lua
@@ -1,0 +1,36 @@
+-- stats commands take the form
+--
+--   EVALSHA sha 1 key group
+--
+-- Note: strictly, it is illegal for a script to manipulate keys that are not
+-- explicitly passed to EVAL{,SHA}, but in practice this is fine as long as all
+-- keys are on the same server (e.g. in cluster scenarios). In our case a single
+-- queue, which may be composed of multiple streams and metadata keys, is always
+-- on the same server.
+
+local base = KEYS[1]
+local group = ARGV[1]
+
+local key_meta = base .. ':meta'
+
+local streams = tonumber(redis.call('HGET', key_meta, 'streams') or 1)
+local len = 0
+local pending_count = 0
+
+for idx = 0, streams-1 do
+  local stream = base .. ':s' .. idx
+
+  len = len + redis.call('XLEN', stream)
+  local info = redis.pcall('XPENDING', stream, group)
+  if info['err'] then
+    if string.match(info['err'], '^NOGROUP ') then
+      -- if either the stream or group don't exist, there are zero pending entries
+    else
+      return redis.error_reply(info['err']..' accessing '..stream)
+    end
+  else
+    pending_count = pending_count + info[1]
+  end
+end
+
+return {len, pending_count}


### PR DESCRIPTION
This is just like #160, but we calculate length and pending count atomically.

Before this change, I was subtracting the pending count from the length to get a "waiting messages" metric; but as these numbers could not be measured atomically I sometimes saw negative waiting messages.

This changes PendingCount() into Stats() which returns both length and pending count.