### PR TITLE
require go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicate/go
 
-go 1.22
+go 1.23
 
 require (
 	github.com/alicebob/miniredis/v2 v2.34.0


### PR DESCRIPTION
This updates our library to require go 1.23.

If we bump all our dependencies, we have an indirect dependency on go 1.22.7:

go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v1.33.0 requires go >= 1.22.7

We want to use 1.23 everywhere anyway (except replicate-go, but that doesn't depend on this library).