### PR TITLE
Do not try and send empty errors to sentry

### DIFF
--- a/telemetry/exporters.go
+++ b/telemetry/exporters.go
@@ -49,6 +49,8 @@ func (u *UTF8ErrorCatchingExporter) ExportSpans(ctx context.Context, spans []tra
 		spanJSON, marshalErr := json.Marshal(spanData)
 		if marshalErr != nil {
 			log.Errorw("Error marshalling span data", "error", marshalErr)
+			sentry.CaptureException(marshalErr)
+			return marshalErr
 		}
 		// Send to Sentry
 		sentry.CaptureMessage(string(spanJSON))

--- a/telemetry/exporters.go
+++ b/telemetry/exporters.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/getsentry/sentry-go"
@@ -48,7 +49,8 @@ func (u *UTF8ErrorCatchingExporter) ExportSpans(ctx context.Context, spans []tra
 		log.Errorw("Span data", "span", spanData)
 		spanJSON, marshalErr := json.Marshal(spanData)
 		if marshalErr != nil {
-			log.Errorw("Error marshalling span data", "error", marshalErr)
+			marshalErr = fmt.Errorf("failed to marshal span data on invalid utf-8 span export error capture: %w", marshalErr)
+			log.Errorw("unable to marshal span data", "error", marshalErr)
 			sentry.CaptureException(marshalErr)
 			return marshalErr
 		}


### PR DESCRIPTION
When marshalling the span data, if something cannot be converted to JSON send the marshalling error don't send the empty spanJSON