### PR TITLE
Add util function to copy fields between structs

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,23 @@
+package util
+
+import "reflect"
+
+// CopyFields copies any fields with the same name and type from one struct to another
+func CopyFields[A any, B any](a *A, b *B) {
+	val := reflect.Indirect(reflect.ValueOf(a))
+	val2 := reflect.Indirect(reflect.ValueOf(b))
+	for i := 0; i < val.Type().NumField(); i++ {
+		name := val.Type().Field(i).Name
+		field := val2.FieldByName(name)
+		if !field.IsValid() {
+			continue
+		}
+		if val.Type().Field(i).Type != field.Type() {
+			continue
+		}
+		if !val.Type().Field(i).IsExported() {
+			continue
+		}
+		field.Set(reflect.Indirect(reflect.ValueOf(a)).FieldByName(name))
+	}
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,160 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyFields_Normal(t *testing.T) {
+	type a struct {
+		Thing        int
+		AnotherThing string
+		OneMoreThing bool
+	}
+
+	type b struct {
+		Thing        int
+		AnotherThing string
+	}
+
+	thing1 := &a{
+		Thing:        123,
+		AnotherThing: "abc",
+		OneMoreThing: false,
+	}
+
+	thing2 := &b{}
+
+	CopyFields(thing1, thing2)
+	assert.Equal(t, thing2.Thing, 123)
+	assert.Equal(t, thing2.AnotherThing, "abc")
+}
+
+func TestCopyFields_Unexported(t *testing.T) {
+	type a struct {
+		thing        int
+		anotherThing string
+		oneMoreThing bool
+	}
+
+	type b struct {
+		thing        int
+		anotherThing string
+	}
+
+	thing1 := &a{
+		thing:        123,
+		anotherThing: "abc",
+		oneMoreThing: false,
+	}
+
+	thing2 := &b{}
+
+	CopyFields(thing1, thing2)
+	assert.Equal(t, thing2.thing, 0)
+	assert.Equal(t, thing2.anotherThing, "")
+}
+
+func TestCopyFields_DifferentType(t *testing.T) {
+	type a struct {
+		Thing        int
+		AnotherThing string
+		OneMoreThing bool
+	}
+
+	type b struct {
+		Thing        int
+		AnotherThing string
+		OneMoreThing string
+	}
+
+	thing1 := &a{
+		Thing:        123,
+		AnotherThing: "abc",
+		OneMoreThing: false,
+	}
+
+	thing2 := &b{}
+
+	CopyFields(thing1, thing2)
+	assert.Equal(t, thing2.Thing, 123)
+	assert.Equal(t, thing2.AnotherThing, "abc")
+	assert.Equal(t, thing2.OneMoreThing, "")
+}
+
+func TestCopyFields_UnexportedReceiver(t *testing.T) {
+	type a struct {
+		Thing        int
+		AnotherThing string
+		OneMoreThing bool
+	}
+
+	type b struct {
+		thing        int
+		anotherThing string
+	}
+
+	thing1 := &a{
+		Thing:        123,
+		AnotherThing: "abc",
+		OneMoreThing: false,
+	}
+
+	thing2 := &b{}
+
+	CopyFields(thing1, thing2)
+	assert.Equal(t, thing2.thing, 0)
+	assert.Equal(t, thing2.anotherThing, "")
+}
+
+func TestCopyFields_RefField(t *testing.T) {
+	type a struct {
+		Thing        map[string]string
+		AnotherThing string
+	}
+
+	type b struct {
+		Thing map[string]string
+	}
+
+	thing1 := &a{
+		Thing: map[string]string{
+			"a": "b",
+			"c": "d",
+		},
+	}
+
+	thing2 := &b{}
+
+	CopyFields(thing1, thing2)
+	assert.Equal(t, thing2.Thing, map[string]string{
+		"a": "b",
+		"c": "d",
+	})
+}
+
+func TestCopyFields_Func(t *testing.T) {
+	type a struct {
+		Thing        func(int) string
+		AnotherThing int
+	}
+
+	type b struct {
+		Thing        func(int) string
+		AnotherThing string
+	}
+
+	thing1 := &a{
+		Thing: func(i int) string {
+			return fmt.Sprintf("hello %d", i)
+		},
+	}
+
+	thing2 := &b{}
+
+	CopyFields(thing1, thing2)
+	assert.Equal(t, thing2.Thing(123), "hello 123")
+	assert.Equal(t, thing2.AnotherThing, "")
+}


### PR DESCRIPTION
### Summary

We should have a function that allows us to copy in fields from one struct to another if they have the same name. This seems like a pretty niche thing - and it probably is. However, what inspired this was the Go Redis client, which has [this](https://github.com/redis/go-redis/blob/4bd5d417ca593abff98bbb49cbb6354e6f9bca6f/universal.go) struct that we want. However, that struct is based on [this](https://github.com/redis/go-redis/blob/4bd5d417ca593abff98bbb49cbb6354e6f9bca6f/options.go#L31) struct, but has a couple more fancy items. The problem with this is that we really want to use [this function](https://github.com/redis/go-redis/blob/4bd5d417ca593abff98bbb49cbb6354e6f9bca6f/options.go#L293), because we don't want to do all the networking code by hand, so we will get an `Options` struct back, but we want a `UniversalOptions` struct back instead. So we can either create a copy function which manually does ```options.Field = universalOptions.Field``` once for each of the like 40 fields common to both structs, or do some reflect shenanigans like in the PR here.

### Test Plan

Unit tests added to verify functionality