### PR TITLE
Add shadow write support for cache client

### DIFF
--- a/cache/options.go
+++ b/cache/options.go
@@ -1,15 +1,20 @@
 package cache
 
-import "time"
+import (
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
 
 type Option interface {
 	apply(*cacheOptions)
 }
 
 type cacheOptions struct {
-	Fresh    time.Duration
-	Stale    time.Duration
-	Negative time.Duration
+	Fresh             time.Duration
+	Stale             time.Duration
+	Negative          time.Duration
+	ShadowWriteClient redis.Cmdable
 }
 
 type optionFunc func(*cacheOptions)
@@ -23,5 +28,14 @@ func (fn optionFunc) apply(opts *cacheOptions) {
 func WithNegativeCaching(duration time.Duration) Option {
 	return optionFunc(func(opts *cacheOptions) {
 		opts.Negative = duration
+	})
+}
+
+// WithShadowWrite configures the cache to use a separate Redis client for
+// shadow writes. This is useful for writing to a different Redis instance
+// than the one used for reading. This is useful for write-through caching
+func WithShadowWriteClient(client redis.Cmdable) Option {
+	return optionFunc(func(opts *cacheOptions) {
+		opts.ShadowWriteClient = client
 	})
 }

--- a/cache/options.go
+++ b/cache/options.go
@@ -32,8 +32,8 @@ func WithNegativeCaching(duration time.Duration) Option {
 }
 
 // WithShadowWrite configures the cache to use a separate Redis client for
-// shadow writes. This is useful for writing to a different Redis instance
-// than the one used for reading. This is useful for write-through caching
+// shadow writes. This is useful for writing an additional copy of data to a
+// different Redis instance than the primary instance used for caching.
 func WithShadowWriteClient(client redis.Cmdable) Option {
 	return optionFunc(func(opts *cacheOptions) {
 		opts.ShadowWriteClient = client


### PR DESCRIPTION
- **feat(cache): add shadow write client support with logging & tracing**
  - Introduce ShadowWriteClient option for fire-and-forget writes
  - Implement writes to shadow client in set() and setNegative()
  - Add structured logging and OpenTelemetry tracing for shadow operations
  

- **test: ensure cache operations succeed when shadow client fails**
  