### PR TITLE
Require explicit timeout for shadow write client operations

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -301,7 +301,7 @@ func (c *Cache[T]) set(ctx context.Context, key string, value T) error {
 	if c.opts.ShadowWriteClient != nil {
 		// Fire-and-forget shadow write
 		go func() {
-			ctx, cancel := context.WithTimeout(ctx, c.opts.ShadowWriteTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), c.opts.ShadowWriteTimeout)
 			defer cancel()
 
 			ctx, span := tracer.Start(
@@ -341,7 +341,7 @@ func (c *Cache[T]) setNegative(ctx context.Context, key string) error {
 	if c.opts.ShadowWriteClient != nil {
 		// Fire-and-forget shadow write
 		go func() {
-			ctx, cancel := context.WithTimeout(ctx, c.opts.ShadowWriteTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), c.opts.ShadowWriteTimeout)
 			defer cancel()
 
 			ctx, span := tracer.Start(

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -532,7 +532,7 @@ func TestCacheWithShadowWriteClient(t *testing.T) {
 	shadowClient, shadowMock := redismock.NewClientMock()
 	shadowMock.MatchExpectationsInOrder(false)
 
-	cache := NewCache[testObj](client, "objects", fresh, stale, WithShadowWriteClient(shadowClient))
+	cache := NewCache[testObj](client, "objects", fresh, stale, WithShadowWriteClient(shadowClient, 1*time.Second))
 
 	obj := testObj{Value: "value_for:elephant"}
 
@@ -573,7 +573,7 @@ func TestCacheWithShadowWriteClientDirectSet(t *testing.T) {
 	shadowClient, shadowMock := redismock.NewClientMock()
 	shadowMock.MatchExpectationsInOrder(false)
 
-	cache := NewCache[testObj](client, "objects", fresh, stale, WithShadowWriteClient(shadowClient))
+	cache := NewCache[testObj](client, "objects", fresh, stale, WithShadowWriteClient(shadowClient, 1*time.Second))
 
 	obj := testObj{Value: "direct_set_value"}
 
@@ -615,7 +615,7 @@ func TestCacheWithShadowWriteClientNegative(t *testing.T) {
 
 	cache := NewCache[testObj](client, "objects", fresh, stale,
 		WithNegativeCaching(negative),
-		WithShadowWriteClient(shadowClient))
+		WithShadowWriteClient(shadowClient, 1*time.Second))
 
 	// Expectations for primary client
 	cacheMock.ExpectCacheFetchEmpty("elephant")
@@ -652,7 +652,7 @@ func TestCacheMultipleBackendsWithShadowWriteClient(t *testing.T) {
 		"objects",
 		fresh,
 		stale,
-		WithShadowWriteClient(shadowClient),
+		WithShadowWriteClient(shadowClient, 1*time.Second),
 	)
 
 	obj := testObj{Value: "value_for:elephant"}
@@ -726,7 +726,7 @@ func TestCacheOperationsSucceedWhenShadowClientFails(t *testing.T) {
 	// Create cache
 	cache := NewCache[testObj](client, "objects", fresh, stale,
 		WithNegativeCaching(negative),
-		WithShadowWriteClient(shadowClient))
+		WithShadowWriteClient(shadowClient, 1*time.Second))
 
 	// Test 1: Set succeeds despite shadow failure
 	obj := testObj{Value: "shadow_failure_test"}

--- a/cache/options.go
+++ b/cache/options.go
@@ -11,10 +11,11 @@ type Option interface {
 }
 
 type cacheOptions struct {
-	Fresh             time.Duration
-	Stale             time.Duration
-	Negative          time.Duration
-	ShadowWriteClient redis.Cmdable
+	Fresh              time.Duration
+	Stale              time.Duration
+	Negative           time.Duration
+	ShadowWriteClient  redis.Cmdable
+	ShadowWriteTimeout time.Duration
 }
 
 type optionFunc func(*cacheOptions)
@@ -34,8 +35,9 @@ func WithNegativeCaching(duration time.Duration) Option {
 // WithShadowWrite configures the cache to use a separate Redis client for
 // shadow writes. This is useful for writing an additional copy of data to a
 // different Redis instance than the primary instance used for caching.
-func WithShadowWriteClient(client redis.Cmdable) Option {
+func WithShadowWriteClient(client redis.Cmdable, timeout time.Duration) Option {
 	return optionFunc(func(opts *cacheOptions) {
 		opts.ShadowWriteClient = client
+		opts.ShadowWriteTimeout = timeout
 	})
 }


### PR DESCRIPTION
### summary

The initial implementation of a shadow write client had an unbound context that could potentially lead to _a lot of_ goroutine leakage. This change introduces an explicit timeout for all shadow write client usage so that goroutines have _some_ bounding.

### testing

Existing Go tests only.

Connected to RUNT-29