### PR TITLE
Support rates less than 1 for rate limiting

### DIFF
--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -63,12 +63,12 @@ func (l Limiter) Prepare(ctx context.Context) error {
 //
 // Note: if >1 tokens are requested the Result may indicate partial fulfillment
 // of the request by setting OK == false but Tokens > 0 on the Result.
-func (l Limiter) Take(ctx context.Context, key string, tokens, rate, capacity int) (*Result, error) {
+func (l Limiter) Take(ctx context.Context, key string, tokens int, rate float64, capacity int) (*Result, error) {
 	if tokens < 0 {
 		return nil, fmt.Errorf("%w (tokens=%d)", ErrNegativeInput, tokens)
 	}
 	if rate < 0 {
-		return nil, fmt.Errorf("%w (rate=%d)", ErrNegativeInput, rate)
+		return nil, fmt.Errorf("%w (rate=%f)", ErrNegativeInput, rate)
 	}
 	if capacity < 0 {
 		return nil, fmt.Errorf("%w (capacity=%d)", ErrNegativeInput, capacity)
@@ -89,9 +89,9 @@ func (l Limiter) Take(ctx context.Context, key string, tokens, rate, capacity in
 // the specific limiter being queried. If the token is granted, the request can
 // then look up the appropriate context for the request and call SetOptions to
 // ensure that future requests are handled with the correct rate and capacity.
-func (l Limiter) SetOptions(ctx context.Context, key string, rate, capacity int) error {
+func (l Limiter) SetOptions(ctx context.Context, key string, rate float64, capacity int) error {
 	if rate < 0 {
-		return fmt.Errorf("%w (rate=%d)", ErrNegativeInput, rate)
+		return fmt.Errorf("%w (rate=%f)", ErrNegativeInput, rate)
 	}
 	if capacity < 0 {
 		return fmt.Errorf("%w (capacity=%d)", ErrNegativeInput, capacity)

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -30,7 +31,7 @@ func TestLimiterIntegration(t *testing.T) {
 	demandRate := 200
 
 	// rate limiter parameters
-	rate := 42
+	rate := 42.0
 	capacity := 5
 
 	deadline := time.After(time.Duration(duration) * time.Second)
@@ -55,7 +56,7 @@ Outer:
 	}
 
 	expectedTotal := demandRate * duration
-	expectedPermitted := rate * duration
+	expectedPermitted := int(math.Floor(rate * float64(duration)))
 
 	// allow up to 1% error
 	assert.InDelta(t, expectedTotal, permitted+denied, float64(expectedTotal/100))

--- a/ratelimit/token_bucket.lua
+++ b/ratelimit/token_bucket.lua
@@ -23,15 +23,28 @@ local time_since_fill = now - last_fill_time
 local tokens_to_add = (time_since_fill / 1e6) * rate
 tokens = math.min(tokens + tokens_to_add, capacity)
 
+-- Get the time the last token would have been filled
+if tokens == capacity then
+    -- Always keep the last fill time up to date if the bucket is full so we
+    -- start penalizing immediately
+    last_fill_time = now
+else
+    -- Add the number of tokens * the time to fill one token to the fill time
+    last_fill_time = last_fill_time + (math.floor(tokens_to_add) * (1e6/rate))
+end
+
+-- Never fill more than the floor of tokens
+tokens = math.floor(math.min(tokens + tokens_to_add, capacity))
+
 -- Grant as many (whole) tokens as we can and remove them from the bucket
-local tokens_granted = math.min(math.floor(tokens), tokens_requested)
+local tokens_granted = math.min(tokens, tokens_requested)
 tokens = tokens - tokens_granted
 
 -- Calculate the time until the bucket is refilled
-local time_to_full_bucket = math.ceil((capacity - tokens) / rate)
+local time_to_full_bucket = math.ceil(((capacity - tokens) / rate) - ((now - last_fill_time) / 1e6))
 
 -- Save state and return the results
-redis.call('HSET', KEYS[1], 'tokens', tokens, 'last_fill_time', now, 'rate', rate, 'capacity', capacity)
+redis.call('HSET', KEYS[1], 'tokens', tokens, 'last_fill_time', last_fill_time, 'rate', rate, 'capacity', capacity)
 
 -- Expire the key one second after the bucket is full
 redis.call('EXPIRE', KEYS[1], time_to_full_bucket + 1)

--- a/ratelimit/token_bucket_test.lua
+++ b/ratelimit/token_bucket_test.lua
@@ -1,0 +1,174 @@
+print('-- TEST SUITE BEGIN --')
+
+function print_table(t)
+	for k, v in pairs(t) do
+		print(k.."="..v)
+	end
+end
+
+function print_list(t)
+	for k, v in pairs(t) do
+		print(v)
+	end
+end
+
+-- Left in as a utility function for debugging. If you need to see the state, use this
+function print_state(s)
+	print("tokens="..s[1].." last_fill_time="..s[2].." rate="..s[3].." capacity="..s[4])
+end
+
+function print_return_val(granted, tokens, time_to_full_bucket)
+	print("tokens_granted="..granted.." tokens_in_bucket="..tokens.." time_to_full_bucket="..time_to_full_bucket)
+end
+
+-- This function should just hold the core logic of token_bucket.lua, ignoring any redis
+function limit(now, state, tokens_requested, rate, capacity)
+	-- If this is a new limiter, the bucket is full
+	local tokens = tonumber(state[1], 10) or capacity
+	-- NOTE: tonumber with base 10 will be sad here, unlike from redis
+	local last_fill_time = tonumber(state[2]) or now
+	
+	-- Add tokens accrued since the last fill
+	local time_since_fill = now - last_fill_time
+	local tokens_to_add = (time_since_fill / 1e6) * rate
+
+	-- Get the time the last token would have been filled
+	if tokens == capacity then
+		-- Always keep the last fill time up to date if the bucket is full so we
+		-- start penalizing immediately
+		last_fill_time = now
+	else
+		-- Add the number of tokens * the time to fill one token to the fill time
+		last_fill_time = last_fill_time + (math.floor(tokens_to_add) * (1e6/rate))
+	end
+
+	-- Never fill more than the floor of tokens
+	tokens = math.floor(math.min(tokens + tokens_to_add, capacity))
+	
+	-- Grant as many (whole) tokens as we can and remove them from the bucket
+	local tokens_granted = math.min(tokens, tokens_requested)
+	tokens = tokens - tokens_granted
+	
+	-- Calculate the time until the bucket is refilled
+	local time_to_full_bucket = math.ceil(((capacity - tokens) / rate) - ((now - last_fill_time) / 1e6))
+
+	return tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity
+end
+
+function test_rate_less_than_1()
+	-- This test just tests the core logic of the rate limiter
+
+	-- Set the base time to some random time (this is the time I wrote this test)
+	local now = 1749676283*1e6
+	-- Make this a little bit in the past
+	local time = tostring(now - 1e2)
+	local state = {"1", tostring(now - 1e2), "0.4", "1"}
+
+	tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity = limit(now, state, 1, 0.4, 1)
+
+	state = {tostring(tokens), tostring(last_fill_time), tostring(rate), tostring(capacity)}
+	print_return_val(tokens_granted, tokens, time_to_full_bucket)
+
+	assert(tokens_granted == 1, "Wrong number of tokens granted for base case")
+	assert(time_to_full_bucket == 3, "Wrong time_to_fill_bucket value for base case")
+
+	-- Advance the time by 1 second. The time to fill the bucket should say 2 seconds now
+	print()
+	now = now + 1e6
+
+	tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity = limit(now, state, 1, 0.4, 1)
+
+	state = {tostring(tokens), tostring(last_fill_time), tostring(rate), tostring(capacity)}
+	print_return_val(tokens_granted, tokens, time_to_full_bucket)
+
+	assert(tokens_granted == 0, "Wrong number of tokens granted after 1 second")
+	assert(time_to_full_bucket == 2, "Wrong time_to_fill_bucket value after 1 second")
+	
+	-- Advance the time by 1 second. The time to fill the bucket should say 1 seconds now
+	print()
+	now = now + 1e6
+
+	tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity = limit(now, state, 1, 0.4, 1)
+
+	state = {tostring(tokens), tostring(last_fill_time), tostring(rate), tostring(capacity)}
+	print_return_val(tokens_granted, tokens, time_to_full_bucket)
+
+	assert(tokens_granted == 0, "Wrong number of tokens granted after 2 seconds")
+	assert(time_to_full_bucket == 1, "Wrong time_to_fill_bucket value after 2 seconds")
+	
+	-- Advance the time by 0.5 seconds. The bucket should grant a token, and say 3 seconds left to fill
+	print()
+	now = now + 5e5
+
+	tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity = limit(now, state, 1, 0.4, 1)
+
+	state = {tostring(tokens), tostring(last_fill_time), tostring(rate), tostring(capacity)}
+	print_return_val(tokens_granted, tokens, time_to_full_bucket)
+
+	assert(tokens_granted == 1, "Wrong number of tokens granted after 3 seconds")
+	assert(time_to_full_bucket == 3, "Wrong time_to_fill_bucket value after 3 seconds")
+end
+
+function test_rate_greater_than_1()
+	-- This test just tests the core logic of the rate limiter
+
+	-- Set the base time to some random time (this is the time I wrote this test)
+	local now = 1749676283*1e6
+	-- Make this a little bit in the past
+	local time = tostring(now - 1e2)
+	local state = {"100", tostring(now - 1e2), "10", "100"}
+
+	tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity = limit(now, state, 20, 10, 100)
+
+	state = {tostring(tokens), tostring(last_fill_time), tostring(rate), tostring(capacity)}
+	print_return_val(tokens_granted, tokens, time_to_full_bucket)
+
+	assert(tokens_granted == 20, "Wrong number of tokens granted for base case")
+	assert(time_to_full_bucket == 2, "Wrong time_to_fill_bucket value for base case")
+
+	-- Advance the time by 1 second. There should be 90 tokens in the bucket now
+	print()
+	now = now + 1e6
+
+	tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity = limit(now, state, 50, 10, 100)
+
+	state = {tostring(tokens), tostring(last_fill_time), tostring(rate), tostring(capacity)}
+	print_return_val(tokens_granted, tokens, time_to_full_bucket)
+
+	assert(tokens_granted == 50, "Wrong number of tokens granted after 1 second")
+	assert(time_to_full_bucket == 6, "Wrong time_to_fill_bucket value after 1 second")
+	
+	-- Advance the time by 1 second. There should be 50 tokens in the bucket now
+	print()
+	now = now + 1e6
+
+	tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity = limit(now, state, 60, 10, 100)
+
+	state = {tostring(tokens), tostring(last_fill_time), tostring(rate), tostring(capacity)}
+	print_return_val(tokens_granted, tokens, time_to_full_bucket)
+
+	assert(tokens_granted == 50, "Wrong number of tokens granted after 2 seconds")
+	assert(time_to_full_bucket == 10, "Wrong time_to_fill_bucket value after 2 seconds")
+	
+	-- Advance the time by 20 seconds. There should be 100 tokens in the bucket now
+	print()
+	now = now + 2e7
+
+	tokens_granted, time_to_full_bucket, tokens, last_fill_time, rate, capacity = limit(now, state, 60, 10, 100)
+
+	state = {tostring(tokens), tostring(last_fill_time), tostring(rate), tostring(capacity)}
+	print_return_val(tokens_granted, tokens, time_to_full_bucket)
+
+	assert(tokens_granted == 60, "Wrong number of tokens granted after 3 seconds")
+	assert(time_to_full_bucket == 6, "Wrong time_to_fill_bucket value after 3 seconds")
+end
+
+print('-- TEST BEGIN: rate < 1 --')
+test_rate_less_than_1()
+print('-- TEST END --')
+
+print('-- TEST BEGIN: rate > 1 --')
+test_rate_greater_than_1()
+print('-- TEST END --')
+
+print('-- TEST SUITE END --')


### PR DESCRIPTION
### Summary

Support a floating point rate. In the implementation as current, if multiple calls are made before a whole token is filled, we will starve the process by continually updating the `last_fill_time` whether we filled a token or not, meaning for example if you filled one token every 10s but called the rate limiter every 1s you would never get a token. Removing this bug is necessary for lower fill rates because it is very unlikely to happen when you have 50 rps. We also need to update the `time_to_fill_bucket` because we can no longer assume that the number of tokens needed to fill is a good enough estimate since it may be multiple seconds to fill a single token, so for example a bucket with a capacity of 1 if you call 1 per second, there's no guarantee you've called it in the first second or the 9th second. Therefore we need to return the delta from the last filled token.

### Test Plan

See the tests added in `ratelimit/token_bucket_test.lua`