### PR TITLE
nmurthy/RUNT 172 use go kv in api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
+	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/launchdarkly/go-sdk-common/v3 v3.2.0
 	github.com/launchdarkly/go-server-sdk/v6 v6.2.1
 	github.com/prometheus/client_golang v1.22.0
-	github.com/redis/go-redis/v9 v9.8.0
+	github.com/redis/go-redis/extra/redisotel/v9 v9.10.0
+	github.com/redis/go-redis/v9 v9.10.0
 	github.com/segmentio/ksuid v1.0.4
 	github.com/speps/go-hashids/v2 v2.0.1
 	github.com/stretchr/testify v1.10.0
@@ -55,6 +57,7 @@ require (
 	github.com/launchdarkly/go-semver v1.0.2 // indirect
 	github.com/launchdarkly/go-server-sdk-evaluation/v2 v2.0.2 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/gomega v1.33.1 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
@@ -62,6 +65,7 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.10.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB1
 github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
+github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/karlseguin/expect v1.0.2-0.20190806010014-778a5f0c6003 h1:vJ0Snvo+SLMY72r5J4sEfkuE7AFbixEP2qRbEcum/wA=
@@ -92,6 +94,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -116,8 +120,12 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/redis/go-redis/v9 v9.8.0 h1:q3nRvjrlge/6UD7eTu/DSg2uYiU2mCL0G/uzBWqhicI=
-github.com/redis/go-redis/v9 v9.8.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.10.0 h1:uTiEyEyfLhkw678n6EulHVto8AkcXVr8zUcBJNZ0ark=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.10.0/go.mod h1:eFYL/99JvdLP4T9/3FZ5t2pClnv7mMskc+WstTcyVr4=
+github.com/redis/go-redis/extra/redisotel/v9 v9.10.0 h1:4z7/hCJ9Jft8EBb2tDmK38p2WjyIEJ1ShhhwAhjOCps=
+github.com/redis/go-redis/extra/redisotel/v9 v9.10.0/go.mod h1:B0thqLh4hB8MvvcUKSwyP5YiIcCCp8UrQ0cA9gEqyjk=
+github.com/redis/go-redis/v9 v9.10.0 h1:FxwK3eV8p/CQa0Ch276C7u2d0eNC9kCmAYQ7mCXCzVs=
+github.com/redis/go-redis/v9 v9.10.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=

--- a/kv/integration_test.go
+++ b/kv/integration_test.go
@@ -1,0 +1,395 @@
+//go:build integration
+
+package kv_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/replicate/go/kv"
+)
+
+func TestMain(m *testing.M) {
+	// Ensure we have a Redis URL for testing
+	if os.Getenv("REDIS_URL") == "" {
+		os.Setenv("REDIS_URL", "redis://localhost:6379")
+	}
+
+	// Set test environment
+	os.Setenv("ENVIRONMENT", "test")
+
+	os.Exit(m.Run())
+}
+
+func TestKV_New_Integration(t *testing.T) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	require.NotEmpty(t, redisURL, "REDIS_URL environment variable is required for integration tests")
+
+	t.Run("basic client creation", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-client", redisURL)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Test basic operation
+		err = client.Set(ctx, "test:key", "test-value", time.Minute).Err()
+		require.NoError(t, err)
+
+		val, err := client.Get(ctx, "test:key").Result()
+		require.NoError(t, err)
+		assert.Equal(t, "test-value", val)
+
+		// Cleanup
+		client.Del(ctx, "test:key")
+	})
+
+	t.Run("with custom pool size", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-pool", redisURL, kv.WithPoolSize(15))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Just verify that the client works - we can't easily check pool size
+		// through the redis.Cmdable interface
+		err = client.Ping(ctx).Err()
+		require.NoError(t, err)
+	})
+
+	t.Run("with enhanced logging", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-enhanced", redisURL, kv.WithEnhancedLogging(true))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Test operation to ensure client works
+		err = client.Ping(ctx).Err()
+		require.NoError(t, err)
+	})
+
+	t.Run("with custom trace sampling", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-tracing", redisURL, kv.WithTraceSampling(0.5))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Test operation
+		err = client.Set(ctx, "test:trace", "trace-value", time.Minute).Err()
+		require.NoError(t, err)
+
+		// Cleanup
+		client.Del(ctx, "test:trace")
+	})
+
+	t.Run("multiple clients with shared tracer provider", func(t *testing.T) {
+		// Create first client (this will create the global tracer provider)
+		client1, err := kv.New(ctx, "test-shared-1", redisURL)
+		require.NoError(t, err)
+		require.NotNil(t, client1)
+
+		// Create second client (should reuse the tracer provider)
+		client2, err := kv.New(ctx, "test-shared-2", redisURL)
+		require.NoError(t, err)
+		require.NotNil(t, client2)
+
+		// Test both clients work
+		err = client1.Set(ctx, "test:shared1", "value1", time.Minute).Err()
+		require.NoError(t, err)
+
+		err = client2.Set(ctx, "test:shared2", "value2", time.Minute).Err()
+		require.NoError(t, err)
+
+		// Verify values
+		val1, err := client1.Get(ctx, "test:shared1").Result()
+		require.NoError(t, err)
+		assert.Equal(t, "value1", val1)
+
+		val2, err := client2.Get(ctx, "test:shared2").Result()
+		require.NoError(t, err)
+		assert.Equal(t, "value2", val2)
+
+		// Cleanup
+		client1.Del(ctx, "test:shared1")
+		client2.Del(ctx, "test:shared2")
+	})
+}
+
+func TestKV_ValidationErrors_Integration(t *testing.T) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	require.NotEmpty(t, redisURL)
+
+	t.Run("empty client name", func(t *testing.T) {
+		client, err := kv.New(ctx, "", redisURL)
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "client name cannot be empty")
+	})
+
+	t.Run("empty redis URL", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-client", "")
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "redis URL cannot be empty")
+	})
+
+	t.Run("invalid redis URL", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-client", "invalid-url")
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "failed to parse redis URL")
+	})
+
+	t.Run("invalid pool size", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-client", redisURL, kv.WithPoolSize(-1))
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "pool size must be positive")
+	})
+
+	t.Run("invalid trace sampling rate", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-client", redisURL, kv.WithTraceSampling(1.5))
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "trace sampling rate must be between 0 and 1")
+	})
+
+	t.Run("nil tracer provider", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-client", redisURL, kv.WithTracerProvider(nil))
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "tracer provider cannot be nil")
+	})
+
+	t.Run("empty sentinel addresses", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-client", redisURL, kv.WithSentinel("mymaster", []string{}, "password"))
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Contains(t, err.Error(), "sentinel addresses cannot be empty")
+	})
+}
+
+func TestKV_EnvironmentDefaults_Integration(t *testing.T) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	require.NotEmpty(t, redisURL)
+
+	tests := []struct {
+		name        string
+		environment string
+		expectedMin int
+		expectedMax int
+	}{
+		{"test environment", "test", 5, 5},
+		{"development environment", "development", 10, 10},
+		{"staging environment", "staging", 15, 15},
+		{"production environment", "production", 20, 20},
+		{"unknown environment defaults to development", "unknown", 10, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment
+			originalEnv := os.Getenv("ENVIRONMENT")
+			os.Setenv("ENVIRONMENT", tt.environment)
+			defer os.Setenv("ENVIRONMENT", originalEnv)
+
+			client, err := kv.New(ctx, fmt.Sprintf("test-%s", tt.environment), redisURL)
+			require.NoError(t, err)
+			require.NotNil(t, client)
+
+			// Verify the client works
+			err = client.Ping(ctx).Err()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestKV_TracerProviderCustomization_Integration(t *testing.T) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	require.NotEmpty(t, redisURL)
+
+	t.Run("custom tracer provider", func(t *testing.T) {
+		// Create a mock tracer provider
+		mockProvider := trace.NewNoopTracerProvider()
+
+		client, err := kv.New(ctx, "test-custom-tracer", redisURL, kv.WithTracerProvider(mockProvider))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Test operation
+		err = client.Set(ctx, "test:custom-tracer", "value", time.Minute).Err()
+		require.NoError(t, err)
+
+		// Cleanup
+		client.Del(ctx, "test:custom-tracer")
+	})
+}
+
+func TestKV_ConnectionPoolBehavior_Integration(t *testing.T) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	require.NotEmpty(t, redisURL)
+
+	t.Run("large pool size warning", func(t *testing.T) {
+		// This should generate a warning log but still work
+		client, err := kv.New(ctx, "test-large-pool", redisURL, kv.WithPoolSize(1001))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Verify client works
+		err = client.Ping(ctx).Err()
+		require.NoError(t, err)
+	})
+
+	t.Run("reasonable pool size", func(t *testing.T) {
+		client, err := kv.New(ctx, "test-reasonable-pool", redisURL, kv.WithPoolSize(50))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Test concurrent operations
+		done := make(chan bool, 10)
+		for i := 0; i < 10; i++ {
+			go func(id int) {
+				key := fmt.Sprintf("test:concurrent:%d", id)
+				err := client.Set(ctx, key, fmt.Sprintf("value-%d", id), time.Minute).Err()
+				assert.NoError(t, err)
+
+				val, err := client.Get(ctx, key).Result()
+				assert.NoError(t, err)
+				assert.Equal(t, fmt.Sprintf("value-%d", id), val)
+
+				client.Del(ctx, key)
+				done <- true
+			}(i)
+		}
+
+		// Wait for all goroutines to complete
+		for i := 0; i < 10; i++ {
+			select {
+			case <-done:
+				// success
+			case <-time.After(10 * time.Second):
+				t.Fatal("timeout waiting for concurrent operations")
+			}
+		}
+	})
+}
+
+func TestKV_SentinelConfiguration_Integration(t *testing.T) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	require.NotEmpty(t, redisURL)
+
+	t.Run("sentinel with empty primary name", func(t *testing.T) {
+		// Should succeed but not configure sentinel
+		client, err := kv.New(ctx, "test-no-sentinel", redisURL, kv.WithSentinel("", []string{"sentinel:26379"}, "password"))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Verify client works normally
+		err = client.Ping(ctx).Err()
+		require.NoError(t, err)
+	})
+}
+
+func TestKV_TLSConfiguration_Integration(t *testing.T) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	require.NotEmpty(t, redisURL)
+
+	t.Run("TLS with non-TLS URL", func(t *testing.T) {
+		// Should succeed but not configure TLS since URL doesn't specify TLS
+		client, err := kv.New(ctx, "test-no-tls", redisURL, kv.WithAutoTLS("/nonexistent/ca.crt"))
+		require.NoError(t, err)
+		require.NotNil(t, client)
+
+		// Verify client works
+		err = client.Ping(ctx).Err()
+		require.NoError(t, err)
+	})
+}
+
+// BenchmarkKV_ClientCreation benchmarks the performance of creating Redis clients
+func BenchmarkKV_ClientCreation(b *testing.B) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		b.Skip("REDIS_URL not set, skipping benchmark")
+	}
+
+	b.Run("basic client creation", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			client, err := kv.New(ctx, fmt.Sprintf("bench-%d", i), redisURL)
+			if err != nil {
+				b.Fatal(err)
+			}
+			// Close the client to avoid resource leaks
+			if closer, ok := client.(interface{ Close() error }); ok {
+				closer.Close()
+			}
+		}
+	})
+
+	b.Run("client creation with options", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			client, err := kv.New(ctx, fmt.Sprintf("bench-opts-%d", i), redisURL,
+				kv.WithPoolSize(20),
+				kv.WithTraceSampling(0.1),
+				kv.WithEnhancedLogging(true),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if closer, ok := client.(interface{ Close() error }); ok {
+				closer.Close()
+			}
+		}
+	})
+}
+
+// BenchmarkKV_Operations benchmarks basic Redis operations
+func BenchmarkKV_Operations(b *testing.B) {
+	ctx := context.Background()
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		b.Skip("REDIS_URL not set, skipping benchmark")
+	}
+
+	client, err := kv.New(ctx, "bench-operations", redisURL)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("set operations", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			key := fmt.Sprintf("bench:set:%d", i)
+			err := client.Set(ctx, key, "benchmark-value", time.Minute).Err()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("get operations", func(b *testing.B) {
+		// Pre-populate some keys
+		for i := 0; i < 100; i++ {
+			key := fmt.Sprintf("bench:get:%d", i)
+			client.Set(ctx, key, "benchmark-value", time.Minute)
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			key := fmt.Sprintf("bench:get:%d", i%100)
+			_, err := client.Get(ctx, key).Result()
+			if err != nil && err != redis.Nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -1,0 +1,249 @@
+package kv
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-rootcerts"
+	"github.com/redis/go-redis/extra/redisotel/v9"
+	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/replicate/go/logging"
+	"github.com/replicate/go/telemetry"
+)
+
+var (
+	logger       = logging.New("kv")
+	errEmptyAddr = errors.New("empty Addr field")
+)
+
+// ClientOption allows configuration of Redis client options.
+type ClientOption interface {
+	apply(string, *redis.UniversalOptions) error
+}
+
+type clientOptionFunc func(string, *redis.UniversalOptions) error
+
+func (fn clientOptionFunc) apply(name string, uOpts *redis.UniversalOptions) error {
+	return fn(name, uOpts)
+}
+
+// Noop returns a no-operation client option.
+func Noop() ClientOption {
+	return clientOptionFunc(func(string, *redis.UniversalOptions) error {
+		return nil
+	})
+}
+
+// WithPoolSize sets the connection pool size for the Redis client.
+func WithPoolSize(size int) ClientOption {
+	log := logger.Sugar()
+
+	return clientOptionFunc(func(name string, uOpts *redis.UniversalOptions) error {
+		log.Infow("setting pool size for client", "client_name", name, "pool_size", size)
+		uOpts.PoolSize = size
+
+		return nil
+	})
+}
+
+// WithSentinel configures Redis Sentinel support for high availability.
+func WithSentinel(primaryName string, addrs []string, password string) ClientOption {
+	log := logger.Sugar()
+
+	return clientOptionFunc(func(name string, uOpts *redis.UniversalOptions) error {
+		if primaryName == "" {
+			log.Infow("no primary name set; not configuring", "client_name", name)
+
+			return nil
+		}
+
+		log.Infow(
+			"setting primary name, addrs, and sentinel password for client",
+			"client_name", name,
+			"primary_name", primaryName,
+			"addrs", addrs,
+		)
+
+		uOpts.MasterName = primaryName
+		uOpts.Addrs = addrs
+		uOpts.SentinelPassword = password
+
+		return nil
+	})
+}
+
+// WithAutoTLS configures TLS with automatic certificate verification using the provided CA file.
+func WithAutoTLS(caFile string) ClientOption {
+	log := logger.Sugar()
+
+	return clientOptionFunc(func(name string, uOpts *redis.UniversalOptions) error {
+		if uOpts.TLSConfig == nil {
+			log.Infow("no tls config present; not configuring", "client_name", name)
+
+			return nil
+		}
+
+		pool, err := rootcerts.LoadCACerts(&rootcerts.Config{CAFile: caFile})
+		if err != nil {
+			return fmt.Errorf("failed to load certs from CA file %q: %w", caFile, err)
+		}
+
+		log.Infow("setting tls config for client", "client_name", name)
+
+		uOpts.TLSConfig = &tls.Config{
+			// Set InsecureSkipVerify to skip default validation which includes server
+			// name verification. We *only* want to validate the issued cert against
+			// the given CA pool. This will not disable VerifyConnection.
+			InsecureSkipVerify: true,
+			MinVersion:         tls.VersionTLS12,
+			VerifyConnection: func(cs tls.ConnectionState) error {
+				log.Debugw(
+					"verifying connection",
+					"server_name", cs.ServerName,
+					"n_peer_certs", len(cs.PeerCertificates),
+				)
+
+				verOpts := x509.VerifyOptions{
+					DNSName:       "", // skip name verification.
+					Intermediates: x509.NewCertPool(),
+					Roots:         pool,
+				}
+
+				for _, cert := range cs.PeerCertificates[1:] {
+					verOpts.Intermediates.AddCert(cert)
+				}
+
+				if _, err := cs.PeerCertificates[0].Verify(verOpts); err != nil {
+					return fmt.Errorf(
+						"failed to verify peer certificate issuer=%q subject=%q: %w",
+						cs.PeerCertificates[0].Issuer.String(),
+						cs.PeerCertificates[0].Subject.String(),
+						err,
+					)
+				}
+
+				return nil
+			},
+		}
+
+		return nil
+	})
+}
+
+// optionsToUniversalOptions converts redis.Options to redis.UniversalOptions.
+func optionsToUniversalOptions(opts *redis.Options) (*redis.UniversalOptions, error) {
+	if opts.Addr == "" {
+		return nil, errEmptyAddr
+	}
+
+	return &redis.UniversalOptions{
+		Addrs:    []string{opts.Addr},
+		DB:       opts.DB,
+		Username: opts.Username,
+		Password: opts.Password,
+
+		// dial & hooks
+		Dialer:    opts.Dialer,
+		OnConnect: opts.OnConnect,
+
+		// protocol/retries
+		Protocol:        opts.Protocol,
+		MaxRetries:      opts.MaxRetries,
+		MinRetryBackoff: opts.MinRetryBackoff,
+		MaxRetryBackoff: opts.MaxRetryBackoff,
+
+		// timeouts
+		DialTimeout:           opts.DialTimeout,
+		ReadTimeout:           opts.ReadTimeout,
+		WriteTimeout:          opts.WriteTimeout,
+		ContextTimeoutEnabled: opts.ContextTimeoutEnabled,
+
+		// pool
+		PoolFIFO:        opts.PoolFIFO,
+		PoolSize:        opts.PoolSize,
+		PoolTimeout:     opts.PoolTimeout,
+		MinIdleConns:    opts.MinIdleConns,
+		MaxIdleConns:    opts.MaxIdleConns,
+		MaxActiveConns:  opts.MaxActiveConns,
+		ConnMaxIdleTime: opts.ConnMaxIdleTime,
+		ConnMaxLifetime: opts.ConnMaxLifetime,
+
+		// TLS & misc
+		TLSConfig:       opts.TLSConfig,
+		DisableIdentity: opts.DisableIdentity,
+		UnstableResp3:   opts.UnstableResp3,
+	}, nil
+}
+
+// New creates a new Redis client from a URL with the given options.
+// Returns a redis.Cmdable interface for maximum compatibility across different use cases.
+//
+// The client is automatically instrumented with OpenTelemetry tracing and tested
+// with a ping operation before being returned.
+//
+// Example usage:
+//
+//	client, err := kv.New(
+//		ctx,
+//		"my-service",
+//		"redis://localhost:6379",
+//		kv.WithSentinel("mymaster", []string{"sentinel1:26379"}, "password"),
+//		kv.WithAutoTLS("/path/to/ca.crt"),
+//		kv.WithPoolSize(10),
+//	)
+func New(ctx context.Context, name, urlString string, clientOpts ...ClientOption) (redis.Cmdable, error) {
+	log := logger.Sugar()
+
+	opts, err := redis.ParseURL(urlString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse redis URL (%s): %w", name, err)
+	}
+
+	uOpts, err := optionsToUniversalOptions(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert redis options to universal options: %w", err)
+	}
+
+	for _, co := range clientOpts {
+		if err := co.apply(name, uOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	samplingTracerProvider, err := telemetry.CreateTracerProvider(
+		context.Background(),
+		sdktrace.WithSampler(sdktrace.TraceIDRatioBased(0.01)),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	client := redis.NewUniversalClient(uOpts)
+
+	if err := redisotel.InstrumentTracing(
+		client,
+		redisotel.WithAttributes(attribute.String("client.name", name)),
+		redisotel.WithTracerProvider(samplingTracerProvider),
+	); err != nil {
+		return nil, err
+	}
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("failed to ping: %w", err)
+	}
+
+	log.Infow(
+		"Built redis client",
+		"client_name", name,
+		"addrs", uOpts.Addrs,
+		"client_type", fmt.Sprintf("%T", client),
+	)
+
+	return client, nil
+}

--- a/kv/kv_test.go
+++ b/kv/kv_test.go
@@ -1,0 +1,269 @@
+package kv
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	// Skip if Redis is not available
+	if !isRedisAvailable() {
+		t.Skip("Redis not available, skipping integration tests")
+	}
+
+	ctx := context.Background()
+	client, err := New(ctx, "test-client", "redis://localhost:6379")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// Test basic functionality
+	err = client.Set(ctx, "test-key", "test-value", time.Minute).Err()
+	require.NoError(t, err)
+
+	val, err := client.Get(ctx, "test-key").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "test-value", val)
+
+	// Cleanup
+	err = client.Del(ctx, "test-key").Err()
+	require.NoError(t, err)
+}
+
+func TestNewWithInvalidURL(t *testing.T) {
+	ctx := context.Background()
+	client, err := New(ctx, "test-client", "invalid-url")
+	assert.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "failed to parse redis URL")
+}
+
+func TestNewWithEmptyAddr(t *testing.T) {
+	// Test a scenario where we can't connect (connection refused)
+	ctx := context.Background()
+	client, err := New(ctx, "test-client", "redis://localhost:9999")
+	assert.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "failed to ping")
+}
+
+func TestWithPoolSize(t *testing.T) {
+	// Skip if Redis is not available
+	if !isRedisAvailable() {
+		t.Skip("Redis not available, skipping integration tests")
+	}
+
+	ctx := context.Background()
+	client, err := New(ctx, "test-client", "redis://localhost:6379", WithPoolSize(5))
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// Test that client works with custom pool size
+	err = client.Ping(ctx).Err()
+	require.NoError(t, err)
+}
+
+func TestWithSentinel(t *testing.T) {
+	// This is a unit test that doesn't require actual sentinel setup
+	opts := &redis.UniversalOptions{}
+
+	option := WithSentinel("mymaster", []string{"sentinel1:26379", "sentinel2:26379"}, "password")
+	err := option.apply("test-client", opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, "mymaster", opts.MasterName)
+	assert.Equal(t, []string{"sentinel1:26379", "sentinel2:26379"}, opts.Addrs)
+	assert.Equal(t, "password", opts.SentinelPassword)
+}
+
+func TestWithSentinelEmpty(t *testing.T) {
+	opts := &redis.UniversalOptions{
+		Addrs: []string{"redis:6379"}, // existing address
+	}
+
+	option := WithSentinel("", []string{"sentinel1:26379"}, "password")
+	err := option.apply("test-client", opts)
+	require.NoError(t, err)
+
+	// Should not modify options when primary name is empty
+	assert.Equal(t, "", opts.MasterName)
+	assert.Equal(t, []string{"redis:6379"}, opts.Addrs) // unchanged
+	assert.Equal(t, "", opts.SentinelPassword)
+}
+
+func TestWithAutoTLS(t *testing.T) {
+	// Test with no TLS config
+	opts := &redis.UniversalOptions{}
+
+	option := WithAutoTLS("/path/to/ca.crt")
+	err := option.apply("test-client", opts)
+	require.NoError(t, err)
+
+	// Should not modify options when TLSConfig is nil
+	assert.Nil(t, opts.TLSConfig)
+}
+
+func TestWithAutoTLSWithExistingConfig(t *testing.T) {
+	// Create a temporary CA file for testing
+	tmpFile, err := os.CreateTemp("", "test-ca-*.crt")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	// Generate a test certificate at runtime
+	cert, key, err := generateTestCert()
+	require.NoError(t, err)
+
+	_, err = tmpFile.WriteString(cert)
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	opts := &redis.UniversalOptions{
+		TLSConfig: &tls.Config{}, // Signal that TLS is wanted
+	}
+
+	option := WithAutoTLS(tmpFile.Name())
+	err = option.apply("test-client", opts)
+	require.NoError(t, err)
+
+	// Should have configured TLS
+	assert.NotNil(t, opts.TLSConfig)
+	assert.True(t, opts.TLSConfig.InsecureSkipVerify)
+	assert.NotNil(t, opts.TLSConfig.VerifyConnection)
+
+	_ = key // Silence unused variable warning
+}
+
+func TestNoop(t *testing.T) {
+	opts := &redis.UniversalOptions{
+		PoolSize: 10,
+	}
+	originalPoolSize := opts.PoolSize
+
+	option := Noop()
+	err := option.apply("test-client", opts)
+	require.NoError(t, err)
+
+	// Should not modify any options
+	assert.Equal(t, originalPoolSize, opts.PoolSize)
+}
+
+func TestOptionsToUniversalOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *redis.Options
+		wantErr bool
+	}{
+		{
+			name: "valid options",
+			opts: &redis.Options{
+				Addr:     "localhost:6379",
+				DB:       1,
+				Username: "user",
+				Password: "pass",
+				PoolSize: 10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty address",
+			opts: &redis.Options{
+				Addr: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uOpts, err := optionsToUniversalOptions(tt.opts)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, uOpts)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, uOpts)
+				assert.Equal(t, []string{tt.opts.Addr}, uOpts.Addrs)
+				assert.Equal(t, tt.opts.DB, uOpts.DB)
+				assert.Equal(t, tt.opts.Username, uOpts.Username)
+				assert.Equal(t, tt.opts.Password, uOpts.Password)
+				assert.Equal(t, tt.opts.PoolSize, uOpts.PoolSize)
+			}
+		})
+	}
+}
+
+// isRedisAvailable checks if Redis is available for testing
+func isRedisAvailable() bool {
+	client := redis.NewClient(&redis.Options{
+		Addr: "localhost:6379",
+	})
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	return client.Ping(ctx).Err() == nil
+}
+
+// generateTestCert generates a self-signed certificate for testing
+func generateTestCert() (certPEM, keyPEM string, err error) {
+	// Generate a private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Create certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{"Test Org"},
+			Country:       []string{"US"},
+			Province:      []string{"CA"},
+			Locality:      []string{"Test City"},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	// Create the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Encode certificate to PEM
+	certPEMBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	}
+	certPEMBytes := pem.EncodeToMemory(certPEMBlock)
+
+	// Encode private key to PEM
+	keyPEMBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+	keyPEMBytes := pem.EncodeToMemory(keyPEMBlock)
+
+	return string(certPEMBytes), string(keyPEMBytes), nil
+}

--- a/kv/kv_test.go
+++ b/kv/kv_test.go
@@ -78,9 +78,10 @@ func TestWithPoolSize(t *testing.T) {
 func TestWithSentinel(t *testing.T) {
 	// This is a unit test that doesn't require actual sentinel setup
 	opts := &redis.UniversalOptions{}
+	cfg := &clientConfig{}
 
 	option := WithSentinel("mymaster", []string{"sentinel1:26379", "sentinel2:26379"}, "password")
-	err := option.apply("test-client", opts)
+	err := option.apply("test-client", opts, cfg)
 	require.NoError(t, err)
 
 	assert.Equal(t, "mymaster", opts.MasterName)
@@ -92,9 +93,10 @@ func TestWithSentinelEmpty(t *testing.T) {
 	opts := &redis.UniversalOptions{
 		Addrs: []string{"redis:6379"}, // existing address
 	}
+	cfg := &clientConfig{}
 
 	option := WithSentinel("", []string{"sentinel1:26379"}, "password")
-	err := option.apply("test-client", opts)
+	err := option.apply("test-client", opts, cfg)
 	require.NoError(t, err)
 
 	// Should not modify options when primary name is empty
@@ -106,9 +108,10 @@ func TestWithSentinelEmpty(t *testing.T) {
 func TestWithAutoTLS(t *testing.T) {
 	// Test with no TLS config
 	opts := &redis.UniversalOptions{}
+	cfg := &clientConfig{}
 
 	option := WithAutoTLS("/path/to/ca.crt")
-	err := option.apply("test-client", opts)
+	err := option.apply("test-client", opts, cfg)
 	require.NoError(t, err)
 
 	// Should not modify options when TLSConfig is nil
@@ -132,9 +135,10 @@ func TestWithAutoTLSWithExistingConfig(t *testing.T) {
 	opts := &redis.UniversalOptions{
 		TLSConfig: &tls.Config{}, // Signal that TLS is wanted
 	}
+	cfg := &clientConfig{}
 
 	option := WithAutoTLS(tmpFile.Name())
-	err = option.apply("test-client", opts)
+	err = option.apply("test-client", opts, cfg)
 	require.NoError(t, err)
 
 	// Should have configured TLS
@@ -149,10 +153,11 @@ func TestNoop(t *testing.T) {
 	opts := &redis.UniversalOptions{
 		PoolSize: 10,
 	}
+	cfg := &clientConfig{}
 	originalPoolSize := opts.PoolSize
 
 	option := Noop()
-	err := option.apply("test-client", opts)
+	err := option.apply("test-client", opts, cfg)
 	require.NoError(t, err)
 
 	// Should not modify any options


### PR DESCRIPTION
- **feat: Introduce consolidated go/kv package for Redis and Valkey clients**
  This commit introduces a new `go/kv` package that provides a consolidated client for interacting with Redis and Valkey key-value stores.
  
  This is so that we can eliminate code duplication for initializing redis universal clients scattered throughout our repos.
  
  The package offers the following features:
  
  - Unified client interface: Provides a single `redis.Cmdable` interface for both Redis and Valkey, simplifying client usage.
  - Connection pooling: Manages a pool of connections to the Redis/Valkey server for improved performance.
  - Sentinel support: Enables high availability by automatically discovering and connecting to Redis/Valkey Sentinel instances.
  - Automatic TLS configuration: Simplifies TLS setup by automatically loading and configuring certificates from a specified CA file.
  - OpenTelemetry instrumentation: Integrates with OpenTelemetry for tracing and monitoring of Redis/Valkey operations.
  
  The following dependencies have been added:
  
  - github.com/redis/go-redis/v9 v9.10.0
  - github.com/redis/go-redis/extra/redisotel/v9 v9.10.0
  - github.com/hashicorp/go-rootcerts v1.0.2
  
  This package simplifies the process of connecting to and interacting with Redis and Valkey databases, providing a more robust and feature-rich client.
  
  (relates to RUNT-171)
  

- **Small improvements + integration test**
  