### PR TITLE
Add Lock TTL/Refresh methods and key existence check

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -369,7 +369,9 @@ type _nullLock struct{}
 
 var nullLock lock.Lock = &_nullLock{}
 
-func (*_nullLock) Release(context.Context) error { return nil }
+func (*_nullLock) Release(context.Context) error                { return nil }
+func (*_nullLock) TTL(context.Context) (time.Duration, error)   { return 0, lock.ErrLockNotHeld }
+func (*_nullLock) Refresh(context.Context, time.Duration) error { return lock.ErrLockNotHeld }
 
 func (c *Cache[T]) acquireIfMultipleRedises(ctx context.Context, key string, ttl time.Duration) (lock.Lock, error) {
 	if len(c.clients) == 1 {

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -247,3 +247,13 @@ func New(ctx context.Context, name, urlString string, clientOpts ...ClientOption
 
 	return client, nil
 }
+
+// Exists checks if a key exists in Redis. Returns true if the key exists, false otherwise.
+// May return an error if it cannot communicate with Redis.
+func Exists(ctx context.Context, client redis.UniversalClient, key string) (bool, error) {
+	result, err := client.Exists(ctx, key).Result()
+	if err != nil {
+		return false, err
+	}
+	return result == 1, nil
+}

--- a/kv/kv_test.go
+++ b/kv/kv_test.go
@@ -234,3 +234,35 @@ func TestNewWithEmptyAddr(t *testing.T) {
 	assert.Nil(t, client)
 	assert.Contains(t, err.Error(), "failed to ping")
 }
+
+func TestExists(t *testing.T) {
+	if os.Getenv("INTEGRATION") != "1" {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := test.Context(t)
+	client := test.Redis(ctx, t)
+
+	// Test key that doesn't exist
+	exists, err := kv.Exists(ctx, client, "nonexistent-key")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Create a key
+	err = client.Set(ctx, "test-key", "test-value", 0).Err()
+	require.NoError(t, err)
+
+	// Test key that exists
+	exists, err = kv.Exists(ctx, client, "test-key")
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// Delete the key
+	err = client.Del(ctx, "test-key").Err()
+	require.NoError(t, err)
+
+	// Test key that no longer exists
+	exists, err = kv.Exists(ctx, client, "test-key")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}


### PR DESCRIPTION
Extends the lock.Lock interface with TTL() and Refresh() methods
needed for compatibility with third-party locking libraries.

Changes:
- Add TTL() method to check remaining lock duration
- Add Refresh() method to extend lock duration
- Add Exists() function to kv package for key existence checks
- Update _nullLock to implement new interface methods
- Add comprehensive tests for new functionality

These additions support migrating hermes and director away from
direct Redis dependencies while maintaining full functionality.
