### PR TITLE
fix: director crashing on startup from empty OTEL env vars

### DIFF
--- a/kv/kv_test.go
+++ b/kv/kv_test.go
@@ -245,7 +245,7 @@ func TestNewWithProblematicOTELAttributes(t *testing.T) {
 	// Save original OTEL env vars
 	originalOtelAttrs := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
 	originalOtelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-	
+
 	defer func() {
 		if originalOtelAttrs == "" {
 			os.Unsetenv("OTEL_RESOURCE_ATTRIBUTES")

--- a/kv/kv_test.go
+++ b/kv/kv_test.go
@@ -234,3 +234,54 @@ func TestNewWithEmptyAddr(t *testing.T) {
 	assert.Nil(t, client)
 	assert.Contains(t, err.Error(), "failed to ping")
 }
+
+// TestNewWithProblematicOTELAttributes tests that kv.New gracefully handles
+// malformed OTEL_RESOURCE_ATTRIBUTES that would normally crash director.
+// This is the defensive behavior we added to prevent startup crashes.
+func TestNewWithProblematicOTELAttributes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	// Save original OTEL env vars
+	originalOtelAttrs := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	originalOtelEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	
+	defer func() {
+		if originalOtelAttrs == "" {
+			os.Unsetenv("OTEL_RESOURCE_ATTRIBUTES")
+		} else {
+			os.Setenv("OTEL_RESOURCE_ATTRIBUTES", originalOtelAttrs)
+		}
+		if originalOtelEndpoint == "" {
+			os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+		} else {
+			os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", originalOtelEndpoint)
+		}
+	}()
+
+	// Set problematic OTEL attributes that would cause "partial resource: missing value" errors
+	// This simulates the same issue that was crashing director pods
+	problematicAttrs := "compute_unit=gpu,model_container.cog_version_override=,version.id=abc123,"
+	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", problematicAttrs)
+	os.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://invalid-endpoint:4317")
+
+	redisURL := test.MiniRedisURL(t)
+
+	// This should not crash even with problematic OTEL attributes
+	client, err := kv.New(ctx, "problematic_otel_test", redisURL)
+	require.NoError(t, err, "kv.New should not fail due to OTEL issues")
+	require.NotNil(t, client, "client should be created despite OTEL problems")
+
+	// Verify Redis functionality still works (telemetry may be disabled)
+	pong, err := client.Ping(ctx).Result()
+	require.NoError(t, err)
+	require.Equal(t, "PONG", pong)
+
+	// Test basic Redis operations
+	err = client.Set(ctx, "defensive-test", "works", time.Minute).Err()
+	require.NoError(t, err)
+
+	val, err := client.Get(ctx, "defensive-test").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "works", val)
+}

--- a/telemetry/resource.go
+++ b/telemetry/resource.go
@@ -21,12 +21,14 @@ var (
 	defaultResourceOnce sync.Once
 )
 
+const otelResourceAttributesEnvVar = "OTEL_RESOURCE_ATTRIBUTES"
+
 // cleanOTELResourceAttributes removes empty key=value pairs and trailing commas
 // from OTEL_RESOURCE_ATTRIBUTES to prevent "partial resource: missing value" errors.
 // This addresses the issue where empty environment variables like COG_VERSION_OVERRIDE=""
 // create malformed attributes that OpenTelemetry rejects.
 func cleanOTELResourceAttributes() {
-	attrs := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	attrs := os.Getenv(otelResourceAttributesEnvVar)
 	if attrs == "" {
 		return
 	}
@@ -51,10 +53,10 @@ func cleanOTELResourceAttributes() {
 
 	// Update the environment variable with cleaned attributes
 	if len(cleaned) > 0 {
-		os.Setenv("OTEL_RESOURCE_ATTRIBUTES", strings.Join(cleaned, ","))
+		os.Setenv(otelResourceAttributesEnvVar, strings.Join(cleaned, ","))
 	} else {
 		// If no valid attributes remain, unset the variable
-		os.Unsetenv("OTEL_RESOURCE_ATTRIBUTES")
+		os.Unsetenv(otelResourceAttributesEnvVar)
 	}
 }
 

--- a/telemetry/resource.go
+++ b/telemetry/resource.go
@@ -3,6 +3,8 @@ package telemetry
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"sync"
 
 	"go.opentelemetry.io/contrib/detectors/gcp"
@@ -19,8 +21,49 @@ var (
 	defaultResourceOnce sync.Once
 )
 
+// cleanOTELResourceAttributes removes empty key=value pairs and trailing commas
+// from OTEL_RESOURCE_ATTRIBUTES to prevent "partial resource: missing value" errors.
+// This addresses the issue where empty environment variables like COG_VERSION_OVERRIDE=""
+// create malformed attributes that OpenTelemetry rejects.
+func cleanOTELResourceAttributes() {
+	attrs := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	if attrs == "" {
+		return
+	}
+
+	// Split by comma and filter out empty parts
+	parts := strings.Split(attrs, ",")
+	var cleaned []string
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		// Check if this is a valid key=value pair
+		if idx := strings.Index(part, "="); idx > 0 && idx < len(part)-1 {
+			// Has both key and value
+			cleaned = append(cleaned, part)
+		}
+		// Skip malformed entries like "key=" or just "="
+	}
+
+	// Update the environment variable with cleaned attributes
+	if len(cleaned) > 0 {
+		os.Setenv("OTEL_RESOURCE_ATTRIBUTES", strings.Join(cleaned, ","))
+	} else {
+		// If no valid attributes remain, unset the variable
+		os.Unsetenv("OTEL_RESOURCE_ATTRIBUTES")
+	}
+}
+
 func DefaultResource() *resource.Resource {
 	defaultResourceOnce.Do(func() {
+		// Clean OTEL_RESOURCE_ATTRIBUTES before creating resource to prevent
+		// "partial resource: missing value" errors from empty values
+		cleanOTELResourceAttributes()
+
 		var err error
 		defaultResource, err = resource.New(
 			context.Background(),

--- a/telemetry/resource_test.go
+++ b/telemetry/resource_test.go
@@ -1,0 +1,157 @@
+package telemetry
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCleanOTELResourceAttributes tests the fix for Sentry issue:
+// https://replicate.sentry.io/issues/DIRECTOR-CG/
+// "Shutdown error: partial resource: missing value: []"
+//
+// This error occurs when OTEL_RESOURCE_ATTRIBUTES contains empty values like:
+// - model_container.cog_version_override= (empty value after =)
+// - Trailing commas from empty EXTRA_OTEL_RESOURCE_ATTRIBUTES
+func TestCleanOTELResourceAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "empty values from COG_VERSION_OVERRIDE",
+			// This is the actual problematic string from affected pods
+			input:    "compute_unit=gpu,compute_unit_count=1,deployable.key=dp-38f7b282eeb0429f8ec38901d1899ad0,deployment.key=dp-38f7b282eeb0429f8ec38901d1899ad0,docker_image_uri=some-image:latest,hardware=nvidia-a100,k8s.container.name=director,k8s.namespace.name=models,k8s.node.name=gpu-node-1,k8s.pod.name=model-dp-38f7b282eeb0429f8ec38901d1899ad0-7d8c544fd9-k55v5,model.full_name=test-user%2Ftest-model,model.id=test-user%2Ftest-model:dp-38f,model.name=test-model,model.owner=test-user,model_container.cog_version=0.11.3,model_container.cog_version_override=,model_container.cog_version_override_raw=%3E=0.11.3,version.id=abc123,",
+			expected: "compute_unit=gpu,compute_unit_count=1,deployable.key=dp-38f7b282eeb0429f8ec38901d1899ad0,deployment.key=dp-38f7b282eeb0429f8ec38901d1899ad0,docker_image_uri=some-image:latest,hardware=nvidia-a100,k8s.container.name=director,k8s.namespace.name=models,k8s.node.name=gpu-node-1,k8s.pod.name=model-dp-38f7b282eeb0429f8ec38901d1899ad0-7d8c544fd9-k55v5,model.full_name=test-user%2Ftest-model,model.id=test-user%2Ftest-model:dp-38f,model.name=test-model,model.owner=test-user,model_container.cog_version=0.11.3,model_container.cog_version_override_raw=%3E=0.11.3,version.id=abc123",
+		},
+		{
+			name:     "trailing comma only",
+			input:    "key1=value1,key2=value2,",
+			expected: "key1=value1,key2=value2",
+		},
+		{
+			name:     "multiple empty values",
+			input:    "key1=value1,empty1=,key2=value2,empty2=,key3=value3",
+			expected: "key1=value1,key2=value2,key3=value3",
+		},
+		{
+			name:     "empty string between commas",
+			input:    "key1=value1,,key2=value2",
+			expected: "key1=value1,key2=value2",
+		},
+		{
+			name:     "already clean attributes",
+			input:    "service.name=test,service.version=1.0.0",
+			expected: "service.name=test,service.version=1.0.0",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only empty values",
+			input:    "empty1=,empty2=,",
+			expected: "",
+		},
+		{
+			name:     "spaces around values",
+			input:    "key1=value1, key2=value2 , empty= , key3=value3",
+			expected: "key1=value1,key2=value2,key3=value3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original value
+			originalValue := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+			defer func() {
+				if originalValue == "" {
+					os.Unsetenv("OTEL_RESOURCE_ATTRIBUTES")
+				} else {
+					os.Setenv("OTEL_RESOURCE_ATTRIBUTES", originalValue)
+				}
+			}()
+
+			// Set the test input
+			os.Setenv("OTEL_RESOURCE_ATTRIBUTES", tt.input)
+
+			// Clean the attributes
+			cleanOTELResourceAttributes()
+
+			// Check the result
+			result := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+			assert.Equal(t, tt.expected, result, "cleanOTELResourceAttributes() should clean attributes correctly")
+
+			// Verify no empty values remain
+			if result != "" {
+				parts := strings.Split(result, ",")
+				for i, part := range parts {
+					assert.NotEmpty(t, part, "Found empty part at index %d", i)
+					assert.False(t, strings.HasSuffix(part, "="), "Found empty value in part %q at index %d", part, i)
+					// Verify it's a valid key=value pair
+					assert.Contains(t, part, "=", "Invalid format (missing =) in part %q at index %d", part, i)
+				}
+			}
+		})
+	}
+}
+
+// TestDefaultResourceWithProblematicAttributes verifies that DefaultResource
+// successfully creates a resource even with problematic OTEL_RESOURCE_ATTRIBUTES
+// that would normally cause "partial resource: missing value: []" errors.
+func TestDefaultResourceWithProblematicAttributes(t *testing.T) {
+	// Save original value and singleton state
+	originalValue := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	originalResource := defaultResource
+	originalOnce := defaultResourceOnce
+	
+	// Reset singleton to ensure our test runs fresh
+	defaultResource = nil
+	defaultResourceOnce = sync.Once{}
+	
+	defer func() {
+		if originalValue == "" {
+			os.Unsetenv("OTEL_RESOURCE_ATTRIBUTES")
+		} else {
+			os.Setenv("OTEL_RESOURCE_ATTRIBUTES", originalValue)
+		}
+		// Restore original singleton state
+		defaultResource = originalResource
+		defaultResourceOnce = originalOnce
+	}()
+
+	// Set the exact problematic attributes from Sentry issue
+	// This reproduces the exact error case where COG_VERSION_OVERRIDE is empty
+	problematicAttrs := "compute_unit=gpu,compute_unit_count=1,deployable.key=dp-38f7b282eeb0429f8ec38901d1899ad0,deployment.key=dp-38f7b282eeb0429f8ec38901d1899ad0,docker_image_uri=r8.im/test/model@sha256:abc123,hardware=nvidia-a40,k8s.container.name=director,k8s.namespace.name=models,k8s.node.name=10.128.0.10,k8s.pod.name=model-dp-38f7b282eeb0429f8ec38901d1899ad0-7d8c544fd9-k55v5,model.full_name=test%2Fmodel,model.id=test%2Fmodel:abc123,model.name=model,model.owner=test,model_container.cog_version=0.12.2,model_container.cog_version_override=,model_container.cog_version_override_raw=%3E=0.11.3,version.id=abc123,"
+
+	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", problematicAttrs)
+
+	// This should not panic or error out
+	resource := DefaultResource()
+
+	// Verify resource was created successfully
+	require.NotNil(t, resource, "DefaultResource() should not return nil")
+
+	// Verify the attributes were cleaned  
+	cleanedAttrs := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	t.Logf("Original attributes: %q", problematicAttrs)
+	t.Logf("Cleaned attributes: %q", cleanedAttrs)
+	
+	// Check that problematic empty values were removed
+	assert.NotContains(t, cleanedAttrs, "model_container.cog_version_override=,", 
+		"Empty value 'model_container.cog_version_override=,' should be removed")
+	assert.False(t, strings.HasSuffix(cleanedAttrs, ","), "Trailing comma should be removed")
+	
+	// Verify all parts are valid
+	parts := strings.Split(cleanedAttrs, ",")
+	for i, part := range parts {
+		assert.NotEmpty(t, part, "Found empty part at index %d", i)
+		assert.False(t, strings.HasSuffix(part, "="), "Found empty value in part %q at index %d", part, i)
+	}
+}

--- a/telemetry/resource_test.go
+++ b/telemetry/resource_test.go
@@ -69,23 +69,23 @@ func TestCleanOTELResourceAttributes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Save original value
-			originalValue := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+			originalValue := os.Getenv(otelResourceAttributesEnvVar)
 			defer func() {
 				if originalValue == "" {
-					os.Unsetenv("OTEL_RESOURCE_ATTRIBUTES")
+					os.Unsetenv(otelResourceAttributesEnvVar)
 				} else {
-					os.Setenv("OTEL_RESOURCE_ATTRIBUTES", originalValue)
+					os.Setenv(otelResourceAttributesEnvVar, originalValue)
 				}
 			}()
 
 			// Set the test input
-			os.Setenv("OTEL_RESOURCE_ATTRIBUTES", tt.input)
+			os.Setenv(otelResourceAttributesEnvVar, tt.input)
 
 			// Clean the attributes
 			cleanOTELResourceAttributes()
 
 			// Check the result
-			result := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+			result := os.Getenv(otelResourceAttributesEnvVar)
 			assert.Equal(t, tt.expected, result, "cleanOTELResourceAttributes() should clean attributes correctly")
 
 			// Verify no empty values remain
@@ -107,7 +107,7 @@ func TestCleanOTELResourceAttributes(t *testing.T) {
 // that would normally cause "partial resource: missing value: []" errors.
 func TestDefaultResourceWithProblematicAttributes(t *testing.T) {
 	// Save original value and singleton state
-	originalValue := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	originalValue := os.Getenv(otelResourceAttributesEnvVar)
 	originalResource := defaultResource
 	originalOnce := defaultResourceOnce
 	
@@ -117,9 +117,9 @@ func TestDefaultResourceWithProblematicAttributes(t *testing.T) {
 	
 	defer func() {
 		if originalValue == "" {
-			os.Unsetenv("OTEL_RESOURCE_ATTRIBUTES")
+			os.Unsetenv(otelResourceAttributesEnvVar)
 		} else {
-			os.Setenv("OTEL_RESOURCE_ATTRIBUTES", originalValue)
+			os.Setenv(otelResourceAttributesEnvVar, originalValue)
 		}
 		// Restore original singleton state
 		defaultResource = originalResource
@@ -130,7 +130,7 @@ func TestDefaultResourceWithProblematicAttributes(t *testing.T) {
 	// This reproduces the exact error case where COG_VERSION_OVERRIDE is empty
 	problematicAttrs := "compute_unit=gpu,compute_unit_count=1,deployable.key=dp-38f7b282eeb0429f8ec38901d1899ad0,deployment.key=dp-38f7b282eeb0429f8ec38901d1899ad0,docker_image_uri=r8.im/test/model@sha256:abc123,hardware=nvidia-a40,k8s.container.name=director,k8s.namespace.name=models,k8s.node.name=10.128.0.10,k8s.pod.name=model-dp-38f7b282eeb0429f8ec38901d1899ad0-7d8c544fd9-k55v5,model.full_name=test%2Fmodel,model.id=test%2Fmodel:abc123,model.name=model,model.owner=test,model_container.cog_version=0.12.2,model_container.cog_version_override=,model_container.cog_version_override_raw=%3E=0.11.3,version.id=abc123,"
 
-	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", problematicAttrs)
+	os.Setenv(otelResourceAttributesEnvVar, problematicAttrs)
 
 	// This should not panic or error out
 	resource := DefaultResource()
@@ -139,7 +139,7 @@ func TestDefaultResourceWithProblematicAttributes(t *testing.T) {
 	require.NotNil(t, resource, "DefaultResource() should not return nil")
 
 	// Verify the attributes were cleaned  
-	cleanedAttrs := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	cleanedAttrs := os.Getenv(otelResourceAttributesEnvVar)
 	t.Logf("Original attributes: %q", problematicAttrs)
 	t.Logf("Cleaned attributes: %q", cleanedAttrs)
 	

--- a/telemetry/resource_test.go
+++ b/telemetry/resource_test.go
@@ -109,12 +109,11 @@ func TestDefaultResourceWithProblematicAttributes(t *testing.T) {
 	// Save original value and singleton state
 	originalValue := os.Getenv(otelResourceAttributesEnvVar)
 	originalResource := defaultResource
-	originalOnce := defaultResourceOnce
-	
+
 	// Reset singleton to ensure our test runs fresh
 	defaultResource = nil
 	defaultResourceOnce = sync.Once{}
-	
+
 	defer func() {
 		if originalValue == "" {
 			os.Unsetenv(otelResourceAttributesEnvVar)
@@ -123,7 +122,7 @@ func TestDefaultResourceWithProblematicAttributes(t *testing.T) {
 		}
 		// Restore original singleton state
 		defaultResource = originalResource
-		defaultResourceOnce = originalOnce
+		defaultResourceOnce = sync.Once{}
 	}()
 
 	// Set the exact problematic attributes from Sentry issue
@@ -138,16 +137,16 @@ func TestDefaultResourceWithProblematicAttributes(t *testing.T) {
 	// Verify resource was created successfully
 	require.NotNil(t, resource, "DefaultResource() should not return nil")
 
-	// Verify the attributes were cleaned  
+	// Verify the attributes were cleaned
 	cleanedAttrs := os.Getenv(otelResourceAttributesEnvVar)
 	t.Logf("Original attributes: %q", problematicAttrs)
 	t.Logf("Cleaned attributes: %q", cleanedAttrs)
-	
+
 	// Check that problematic empty values were removed
-	assert.NotContains(t, cleanedAttrs, "model_container.cog_version_override=,", 
+	assert.NotContains(t, cleanedAttrs, "model_container.cog_version_override=,",
 		"Empty value 'model_container.cog_version_override=,' should be removed")
 	assert.False(t, strings.HasSuffix(cleanedAttrs, ","), "Trailing comma should be removed")
-	
+
 	// Verify all parts are valid
 	parts := strings.Split(cleanedAttrs, ",")
 	for i, part := range parts {


### PR DESCRIPTION
director pods have been crashing with "partial resource: missing value: []"
because of how we build OTEL_RESOURCE_ATTRIBUTES in deployable.go.

The issue:
- COG_VERSION_OVERRIDE is often empty, creating "model_container.cog_version_override="
- EXTRA_OTEL_RESOURCE_ATTRIBUTES isn't set, leaving trailing commas
- OpenTelemetry's parser rejects these malformed attributes

Fixed by cleaning the env var before OpenTelemetry sees it - removes empty
values and trailing commas so we don't crash on startup.

Added tests with the actual problematic strings from affected pods.

Sentry: https://replicate.sentry.io/issues/DIRECTOR-CG/

will have to follow this up with a go lib dependency update in director and we should be good to go :)
