### PR TITLE
Support cancel / delete of in-flight stream messages

### DIFF
--- a/queue/client.go
+++ b/queue/client.go
@@ -285,7 +285,7 @@ type metaCancelation struct {
 // Del supports removal of a message when the given `fieldValue` matches a "meta
 // cancelation" key as written when using a client with tracking support.
 func (c *Client) Del(ctx context.Context, fieldValue string) error {
-	metaCancelationKey := "_meta:cancelation:" + fmt.Sprintf("%x", sha1.Sum([]byte(fieldValue)))
+	metaCancelationKey := fmt.Sprintf("_meta:cancelation:%x", sha1.Sum([]byte(fieldValue)))
 
 	msgBytes, err := c.rdb.Get(ctx, metaCancelationKey).Bytes()
 	if err != nil {

--- a/queue/client.go
+++ b/queue/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -15,9 +16,9 @@ import (
 )
 
 var (
-	ErrInvalidReadArgs           = fmt.Errorf("queue: invalid read arguments")
-	ErrInvalidWriteArgs          = fmt.Errorf("queue: invalid write arguments")
-	ErrNoMatchingMessageInStream = fmt.Errorf("queue: no matching message in stream")
+	ErrInvalidReadArgs           = errors.New("queue: invalid read arguments")
+	ErrInvalidWriteArgs          = errors.New("queue: invalid write arguments")
+	ErrNoMatchingMessageInStream = errors.New("queue: no matching message in stream")
 
 	streamSuffixPattern = regexp.MustCompile(`\A:s(\d+)\z`)
 )

--- a/queue/client_test.go
+++ b/queue/client_test.go
@@ -3,6 +3,7 @@ package queue_test
 import (
 	"context"
 	crand "crypto/rand"
+	"crypto/sha1"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -438,10 +439,12 @@ func TestClientDelIntegration(t *testing.T) {
 	require.Error(t, client.Del(ctx, trackIDs[0]+"oops"))
 	require.Error(t, client.Del(ctx, "bogustown"))
 
-	metaCancel, err := rdb.Get(ctx, "_meta:cancelation:"+trackIDs[1]).Result()
+	metaCancelationKey := "_meta:cancelation:" + fmt.Sprintf("%x", sha1.Sum([]byte(trackIDs[1])))
+
+	metaCancel, err := rdb.Get(ctx, metaCancelationKey).Result()
 	require.NoError(t, err)
 
-	rdb.SetEx(ctx, "_meta:cancelation:"+trackIDs[1], "{{[,"+metaCancel, 5*time.Second)
+	rdb.SetEx(ctx, metaCancelationKey, "{{[,"+metaCancel, 5*time.Second)
 
 	require.Error(t, client.Del(ctx, trackIDs[1]))
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -59,6 +59,10 @@ var (
 	//go:embed write.lua
 	writeCmd    string
 	writeScript = redis.NewScript(writeCmd)
+
+	//go:embed writetracking.lua
+	writeTrackingCmd    string
+	writeTrackingScript = redis.NewScript(writeTrackingCmd)
 )
 
 func prepare(ctx context.Context, rdb redis.Cmdable) error {
@@ -75,6 +79,9 @@ func prepare(ctx context.Context, rdb redis.Cmdable) error {
 		return err
 	}
 	if err := writeScript.Load(ctx, rdb).Err(); err != nil {
+		return err
+	}
+	if err := writeTrackingScript.Load(ctx, rdb).Err(); err != nil {
 		return err
 	}
 	return nil

--- a/queue/write.lua
+++ b/queue/write.lua
@@ -30,6 +30,16 @@ local fields = {unpack(ARGV, 4 + n, #ARGV)}
 local key_meta = base .. ':meta'
 local key_notifications = base .. ':notifications'
 
+local prediction_id = ""
+
+-- Search for prediction_id in fields
+for i = 1, #fields, 2 do
+  if fields[i] == "prediction_id" then
+    prediction_id = fields[i + 1]
+    break
+  end
+end
+
 -- Check args
 if writestreams < 1 then
   return redis.error_reply('ERR streams must be greater than or equal to 1')
@@ -101,6 +111,15 @@ local id = redis.call('XADD', key_stream, '*', unpack(fields))
 
 -- Add a notification to the notifications stream
 redis.call('XADD', key_notifications, 'MAXLEN', '1', '*', 's', selected_sid)
+
+if prediction_id ~= "" then
+  local key_prediction_meta_cancelation = ':meta:cancelation:' .. prediction_id
+  redis.CALL('SET', key_prediction_meta_cancelation, '{"stream_id":"' .. key_stream .. ',"prediction_id":"' .. prediction_id .. ',"msg_id":"' .. id .. '"}')
+  -- Set explicit TTL for the prediction_id cancelation metadata key. Set to 10800 seconds ( 3 hours). If a prediction is not picked
+  -- up within 3 hours we'll let the normal cancelation process take over. This path is intended to allow api to snipe the prediction
+  -- from the queue directly. Additionally API should `DEL` the key after the prediction is picked up/first webhook is sent.
+  redis.call('EXPIRE', key_prediction_meta_cancelation, 10800)
+end
 
 -- Set expiry on selected stream + meta/notifications keys
 redis.call('EXPIRE', key_stream, ttl)

--- a/queue/writetracking.lua
+++ b/queue/writetracking.lua
@@ -116,17 +116,16 @@ local id = redis.call('XADD', key_stream, '*', unpack(fields))
 redis.call('XADD', key_notifications, 'MAXLEN', '1', '*', 's', selected_sid)
 
 if track_value ~= '' then
-  local meta_cancelation_key = '_meta:cancelation:' .. redis.sha1hex(track_value)
   redis.call(
-    'SET',
-    meta_cancelation_key,
+    'SETEX',
+    '_meta:cancelation:' .. redis.sha1hex(track_value),
+    90000, -- 25 hours
     cjson.encode({
       ['stream_id'] = key_stream,
       ['track_value'] = track_value,
       ['msg_id'] = id,
     })
   )
-  redis.call('EXPIRE', meta_cancelation_key, 10800)
 end
 
 -- Set expiry on selected stream + meta/notifications keys


### PR DESCRIPTION
This is a continuation of #154 with the addition of a separate queue client that tracks stream messages and a `Del` method for canceling based on a tracked "key" of the message values map.

Part of RUNT-369 to address canceling in-flight stream messages in general, especially as this applies to prediction streams and their relationship to autoscaling.

The lua file at `queue/writetracking.lua` should be *mostly* the same as `queue/write.lua` but of course that doesn't show in the patch, so here's the diff:

<details>
  <summary><code>diff -u queue/write.lua queue/writetracking.lua</code></summary>

```diff
--- queue/write.lua	2025-09-30 17:26:55
+++ queue/writetracking.lua	2025-10-01 17:38:06
@@ -1,6 +1,6 @@
 -- Write commands take the form
 --
---   EVALSHA sha 1 key seconds streams n sid [sid ...] field value [field value ...]
+--   EVALSHA sha 1 key seconds streams n track_field sid [sid ...] field value [field value ...]
 --
 -- - `key` is the base key for the queue, e.g. "prediction:input:abcd1234"
 -- - `seconds` determines the expiry timeout for all keys that make up the
@@ -10,6 +10,8 @@
 --   and the queue is in the process of resizing.
 -- - `n` is the number of streams this write will consider. It must be less than
 --   or equal to `streams`.
+-- - `track_field` is the name of the key in `fields` used for tracking the stream
+--   message ID for cancelation.
 -- - `sid` are the stream IDs to consider writing to. They must be in the range
 --   [0, `streams`). The message will be written to the shortest of the selected
 --   streams.
@@ -24,12 +26,23 @@
 local ttl = tonumber(ARGV[1], 10)
 local writestreams = tonumber(ARGV[2], 10)
 local n = tonumber(ARGV[3], 10)
-local sids = {unpack(ARGV, 4, 4 + n - 1)}
-local fields = {unpack(ARGV, 4 + n, #ARGV)}
+local track_field = ARGV[4]
+local sids = { unpack(ARGV, 5, 5 + n - 1) }
+local fields = { unpack(ARGV, 5 + n, #ARGV) }
 
 local key_meta = base .. ':meta'
 local key_notifications = base .. ':notifications'
 
+local track_value = ''
+
+-- Search for track_field in fields
+for i = 1, #fields, 2 do
+  if fields[i] == track_field then
+    track_value = fields[i + 1]
+    break
+  end
+end
+
 -- Check args
 if writestreams < 1 then
   return redis.error_reply('ERR streams must be greater than or equal to 1')
@@ -102,6 +115,19 @@
 -- Add a notification to the notifications stream
 redis.call('XADD', key_notifications, 'MAXLEN', '1', '*', 's', selected_sid)
 
+if track_value ~= '' then
+  redis.call(
+    'SETEX',
+    '_meta:cancelation:' .. redis.sha1hex(track_value),
+    90000, -- 25 hours
+    cjson.encode({
+      ['stream_id'] = key_stream,
+      ['track_value'] = track_value,
+      ['msg_id'] = id,
+    })
+  )
+end
+
 -- Set expiry on selected stream + meta/notifications keys
 redis.call('EXPIRE', key_stream, ttl)
 redis.call('EXPIRE', key_meta, ttl)
```

</details>